### PR TITLE
Yolo notebook

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To use you need a copy of `libEMTMLib.so` and valid licence to use it.  Availabl
 sudo mv libEMTMLib.so /usr/local/lib
 sudo ldconfig
 ```
-## Example use 
+## Example: 
 ```python
 import emtmlibpy as emtm
 from emtmlibpy import EMTMResult
@@ -16,3 +16,34 @@ print(emtm_version())
 
 For a full list of examples look at the [unit tests](https://github.com/AutomatedFishID/emtmlibpy/blob/main/src/test_emtmlibpy.py)
 
+## Example: Generate YOLOv5 labels and extract images
+
+The EMObs file and the BRUVS videos need to be in the same directory
+```bash
+./src/scripts/gen_yolo_training_data.py /home/marrabld/data/test_emobs/emtmlibpy/afid.EMObs -o train
+```
+
+Should generate something like 
+
+```bash
+.
+├── gen_yolo_training_data.py
+├── __init__.py
+└── train
+    ├── classes.txt
+    ├── G000048 L_small.m4v_10796.png
+    ├── G000048 L_small.m4v_10796.txt
+    ├── G000048 L_small.m4v_10913.png
+    ├── G000048 L_small.m4v_10913.txt
+    ├── G000048 L_small.m4v_10916.png
+    ├── G000048 L_small.m4v_10916.txt
+    ├── G000048 L_small.m4v_11623.png
+    ├── G000048 L_small.m4v_11623.txt
+```
+
+```bash
+cat test/classes.txt 
+__
+Lethrinidae_Lethrinus_punctulatus
+Lutjanidae_Lutjanus_sebae
+```

--- a/src/notebooks/gen_yolo_training_data.ipynb
+++ b/src/notebooks/gen_yolo_training_data.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 1,
    "outputs": [],
    "source": [
     "import os, sys\n",
@@ -31,9 +31,7 @@
     "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "from collections import namedtuple\n",
-    "#\n",
-    "\n"
+    "from collections import namedtuple"
    ],
    "metadata": {
     "collapsed": false,
@@ -43,8 +41,20 @@
    }
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "### Change this next cell to the path that has the .emobs and video files."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 3,
    "outputs": [],
    "source": [
     "SRC_DIR = os.path.abspath(os.getcwd())\n",
@@ -59,11 +69,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 66,
    "outputs": [],
    "source": [
     "TEST_FILES_PATH = '/home/marrabld/data/test_emobs/emtmlibpy'\n",
     "TEST_FILE = 'afid.EMObs'"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "outputs": [],
+   "source": [
+    "# TEST_FILES_PATH = '/home/marrabld/data/test_emobs/RB95'\n",
+    "# TEST_FILE = '20_ RB95.EMObs_AUTO'"
    ],
    "metadata": {
     "collapsed": false,
@@ -86,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 68,
    "outputs": [
     {
      "name": "stdout",
@@ -120,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 69,
    "outputs": [],
    "source": [
     "r = emtm.em_load_data(os.path.join(TEST_FILES_PATH, TEST_FILE))\n",
@@ -147,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 70,
    "outputs": [
     {
      "name": "stdout",
@@ -175,26 +200,25 @@
    }
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "### Write the classes out to file"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 71,
    "outputs": [],
    "source": [
-    "def xyz_point_to_df():\n",
-    "    \"\"\"\n",
-    "    Given an EM3DPointData return a pandas dataframe\n",
-    "    :return: a pandas dataframe\n",
-    "    \"\"\"\n",
-    "    point_count = emtm.em_3d_point_count()\n",
-    "    p = emtm.em_get_3d_point(0)\n",
-    "    index = [attr for attr in dir(p) if (not attr.startswith('__') and not attr.startswith('_'))]\n",
-    "    data = np.empty(shape=[point_count, len(index)], dtype='|S1024')  # change these\n",
-    "\n",
-    "    for jj in range(point_count):\n",
-    "        p = emtm.em_get_3d_point(jj)\n",
-    "        for ii, ind in enumerate(index):\n",
-    "            data[jj][ii] = p.__getattribute__(ind)\n",
-    "\n",
-    "    return pd.DataFrame(data=data, columns=index)\n"
+    "with open('./train/classes.txt', 'w') as f:\n",
+    "    for _class in fgs:\n",
+    "        f.write(f\"{_class[0].decode('utf-8')}_{_class[1].decode('utf-8')}_{_class[2].decode('utf-8')}\\n\")"
    ],
    "metadata": {
     "collapsed": false,
@@ -205,57 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
-   "outputs": [],
-   "source": [],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
-   "outputs": [],
-   "source": [
-    "xyz_p = xyz_point_to_df()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 43,
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "Empty DataFrame\nColumns: [d_direction, d_imx_left, d_imx_right, d_imy_left, d_imy_right, d_period_time_mins, d_range, d_rms, d_time_mins, dsx, dsy, dsz, dx, dy, dz, n_frame_left, n_frame_right, str_activity, str_att_10, str_att_9, str_code, str_comment, str_family, str_filename_left, str_filename_right, str_genus, str_number, str_op_code, str_period, str_species, str_stage]\nIndex: []\n\n[0 rows x 31 columns]",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>d_direction</th>\n      <th>d_imx_left</th>\n      <th>d_imx_right</th>\n      <th>d_imy_left</th>\n      <th>d_imy_right</th>\n      <th>d_period_time_mins</th>\n      <th>d_range</th>\n      <th>d_rms</th>\n      <th>d_time_mins</th>\n      <th>dsx</th>\n      <th>...</th>\n      <th>str_comment</th>\n      <th>str_family</th>\n      <th>str_filename_left</th>\n      <th>str_filename_right</th>\n      <th>str_genus</th>\n      <th>str_number</th>\n      <th>str_op_code</th>\n      <th>str_period</th>\n      <th>str_species</th>\n      <th>str_stage</th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n<p>0 rows × 31 columns</p>\n</div>"
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "xyz_point_to_df()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 72,
    "outputs": [],
    "source": [
     "def point_to_df():\n",
@@ -265,12 +239,11 @@
     "    \"\"\"\n",
     "    dtype_template = 'object'\n",
     "    point_count, box_count = emtm.em_point_count()\n",
-    "    print(f'points {point_count}')\n",
-    "    print(f'box {box_count}')\n",
+    "    print(f'number of points :: {point_count}')\n",
+    "    print(f'number of boxes :: {box_count}')\n",
     "\n",
     "    p = emtm.em_get_point(0)\n",
     "    index = [attr for attr in dir(p) if (not attr.startswith('__') and not attr.startswith('_'))]\n",
-    "    print(index)\n",
     "    data = np.empty(shape=[point_count, len(index)], dtype=dtype_template)  # change these\n",
     "\n",
     "    for jj in range(point_count):\n",
@@ -281,8 +254,7 @@
     "\n",
     "    xpdf = pd.DataFrame(data=data, columns=index)\n",
     "    xpdf = xpdf.convert_dtypes().infer_objects()\n",
-    "    return xpdf\n",
-    "\n"
+    "    return xpdf"
    ],
    "metadata": {
     "collapsed": false,
@@ -293,44 +265,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 73,
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "points 237\n",
-      "box 237\n",
-      "['d_imx', 'd_imy', 'd_period_time_mins', 'd_rectx', 'd_recty', 'd_time_mins', 'n_frame', 'str_activity', 'str_att_10', 'str_att_9', 'str_code', 'str_comment', 'str_family', 'str_filename', 'str_genus', 'str_number', 'str_op_code', 'str_period', 'str_species', 'str_stage']\n"
+      "number of points :: 237\n",
+      "number of boxes :: 237\n"
      ]
-    }
-   ],
-   "source": [
-    "pdf = point_to_df()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "outputs": [
+    },
     {
      "data": {
-      "text/plain": "     d_imx  d_imy  d_period_time_mins  d_rectx  d_recty  d_time_mins  n_frame  \\\n0      767    420                  -1      108       77     3.868865     6957   \n1      374    579                  -1      290      137     3.868865     6957   \n2      191    407                  -1       65       27     3.868865     6957   \n3      659    388                  -1       27       21     3.868865     6957   \n4      648    533                  -1      360      145     3.868865     6957   \n..     ...    ...                 ...      ...      ...          ...      ...   \n232    969    787                  -1      399      215     9.902671    17807   \n233    678    449                  -1       57       41     9.902671    17807   \n234    912    271                  -1      306      153     9.999434    17981   \n235    938    411                  -1      122       89     9.999434    17981   \n236    951    764                  -1      279      269     9.999434    17981   \n\n    str_activity str_att_10 str_att_9 str_code str_comment str_family  \\\n0     b'Passing'        b''       b''      b''         b''        b''   \n1     b'Passing'        b''       b''      b''         b''        b''   \n2     b'Passing'        b''       b''      b''         b''        b''   \n3     b'Passing'        b''       b''      b''         b''        b''   \n4     b'Passing'        b''       b''      b''         b''        b''   \n..           ...        ...       ...      ...         ...        ...   \n232   b'Passing'        b''       b''      b''         b''        b''   \n233   b'Passing'        b''       b''      b''         b''        b''   \n234   b'Passing'        b''       b''      b''         b''        b''   \n235   b'Passing'        b''       b''      b''         b''        b''   \n236   b'Passing'        b''       b''      b''         b''        b''   \n\n               str_filename str_genus str_number str_op_code str_period  \\\n0    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n1    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n2    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n3    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n4    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n..                      ...       ...        ...         ...        ...   \n232  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n233  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n234  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n235  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n236  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n\n    str_species str_stage  \n0           b''     b'AD'  \n1           b''     b'AD'  \n2           b''     b'AD'  \n3           b''     b'AD'  \n4           b''     b'AD'  \n..          ...       ...  \n232         b''     b'AD'  \n233         b''     b'AD'  \n234         b''     b'AD'  \n235         b''     b'AD'  \n236         b''     b'AD'  \n\n[237 rows x 20 columns]",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>d_imx</th>\n      <th>d_imy</th>\n      <th>d_period_time_mins</th>\n      <th>d_rectx</th>\n      <th>d_recty</th>\n      <th>d_time_mins</th>\n      <th>n_frame</th>\n      <th>str_activity</th>\n      <th>str_att_10</th>\n      <th>str_att_9</th>\n      <th>str_code</th>\n      <th>str_comment</th>\n      <th>str_family</th>\n      <th>str_filename</th>\n      <th>str_genus</th>\n      <th>str_number</th>\n      <th>str_op_code</th>\n      <th>str_period</th>\n      <th>str_species</th>\n      <th>str_stage</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>767</td>\n      <td>420</td>\n      <td>-1</td>\n      <td>108</td>\n      <td>77</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>374</td>\n      <td>579</td>\n      <td>-1</td>\n      <td>290</td>\n      <td>137</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>191</td>\n      <td>407</td>\n      <td>-1</td>\n      <td>65</td>\n      <td>27</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>659</td>\n      <td>388</td>\n      <td>-1</td>\n      <td>27</td>\n      <td>21</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>648</td>\n      <td>533</td>\n      <td>-1</td>\n      <td>360</td>\n      <td>145</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>...</th>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n    </tr>\n    <tr>\n      <th>232</th>\n      <td>969</td>\n      <td>787</td>\n      <td>-1</td>\n      <td>399</td>\n      <td>215</td>\n      <td>9.902671</td>\n      <td>17807</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>233</th>\n      <td>678</td>\n      <td>449</td>\n      <td>-1</td>\n      <td>57</td>\n      <td>41</td>\n      <td>9.902671</td>\n      <td>17807</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>234</th>\n      <td>912</td>\n      <td>271</td>\n      <td>-1</td>\n      <td>306</td>\n      <td>153</td>\n      <td>9.999434</td>\n      <td>17981</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>235</th>\n      <td>938</td>\n      <td>411</td>\n      <td>-1</td>\n      <td>122</td>\n      <td>89</td>\n      <td>9.999434</td>\n      <td>17981</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>236</th>\n      <td>951</td>\n      <td>764</td>\n      <td>-1</td>\n      <td>279</td>\n      <td>269</td>\n      <td>9.999434</td>\n      <td>17981</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n  </tbody>\n</table>\n<p>237 rows × 20 columns</p>\n</div>"
+      "text/plain": "   d_imx  d_imy  d_period_time_mins  d_rectx  d_recty  d_time_mins  n_frame  \\\n0    767    420                  -1      108       77     3.868865     6957   \n1    374    579                  -1      290      137     3.868865     6957   \n2    191    407                  -1       65       27     3.868865     6957   \n3    659    388                  -1       27       21     3.868865     6957   \n4    648    533                  -1      360      145     3.868865     6957   \n\n  str_activity str_att_10 str_att_9 str_code str_comment str_family  \\\n0   b'Passing'        b''       b''      b''         b''        b''   \n1   b'Passing'        b''       b''      b''         b''        b''   \n2   b'Passing'        b''       b''      b''         b''        b''   \n3   b'Passing'        b''       b''      b''         b''        b''   \n4   b'Passing'        b''       b''      b''         b''        b''   \n\n             str_filename str_genus str_number str_op_code str_period  \\\n0  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n1  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n2  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n3  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n4  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n\n  str_species str_stage  \n0         b''     b'AD'  \n1         b''     b'AD'  \n2         b''     b'AD'  \n3         b''     b'AD'  \n4         b''     b'AD'  ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>d_imx</th>\n      <th>d_imy</th>\n      <th>d_period_time_mins</th>\n      <th>d_rectx</th>\n      <th>d_recty</th>\n      <th>d_time_mins</th>\n      <th>n_frame</th>\n      <th>str_activity</th>\n      <th>str_att_10</th>\n      <th>str_att_9</th>\n      <th>str_code</th>\n      <th>str_comment</th>\n      <th>str_family</th>\n      <th>str_filename</th>\n      <th>str_genus</th>\n      <th>str_number</th>\n      <th>str_op_code</th>\n      <th>str_period</th>\n      <th>str_species</th>\n      <th>str_stage</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>767</td>\n      <td>420</td>\n      <td>-1</td>\n      <td>108</td>\n      <td>77</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>374</td>\n      <td>579</td>\n      <td>-1</td>\n      <td>290</td>\n      <td>137</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>191</td>\n      <td>407</td>\n      <td>-1</td>\n      <td>65</td>\n      <td>27</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>659</td>\n      <td>388</td>\n      <td>-1</td>\n      <td>27</td>\n      <td>21</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>648</td>\n      <td>533</td>\n      <td>-1</td>\n      <td>360</td>\n      <td>145</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
-     "execution_count": 46,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "pdf"
+    "pdf = point_to_df()\n",
+    "pdf.head()"
    ],
    "metadata": {
     "collapsed": false,
@@ -341,30 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "0       \n1       \n2       \n3       \n4       \n      ..\n232     \n233     \n234     \n235     \n236     \nName: str_family, Length: 237, dtype: object"
-     },
-     "execution_count": 47,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pdf['str_family'].str.decode('utf-8')"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 74,
    "outputs": [
     {
      "name": "stdout",
@@ -411,22 +345,34 @@
    }
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "### We're only interested in boxes at this stage so subset the data frame to include only boxes"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 75,
    "outputs": [
     {
      "data": {
-      "text/plain": "     d_imx  d_imy  d_period_time_mins  d_rectx  d_recty  d_time_mins  n_frame  \\\n0      767    420                  -1      108       77     3.868865     6957   \n1      374    579                  -1      290      137     3.868865     6957   \n2      191    407                  -1       65       27     3.868865     6957   \n3      659    388                  -1       27       21     3.868865     6957   \n4      648    533                  -1      360      145     3.868865     6957   \n..     ...    ...                 ...      ...      ...          ...      ...   \n232    969    787                  -1      399      215     9.902671    17807   \n233    678    449                  -1       57       41     9.902671    17807   \n234    912    271                  -1      306      153     9.999434    17981   \n235    938    411                  -1      122       89     9.999434    17981   \n236    951    764                  -1      279      269     9.999434    17981   \n\n    str_activity str_att_10 str_att_9 str_code str_comment str_family  \\\n0     b'Passing'        b''       b''      b''         b''        b''   \n1     b'Passing'        b''       b''      b''         b''        b''   \n2     b'Passing'        b''       b''      b''         b''        b''   \n3     b'Passing'        b''       b''      b''         b''        b''   \n4     b'Passing'        b''       b''      b''         b''        b''   \n..           ...        ...       ...      ...         ...        ...   \n232   b'Passing'        b''       b''      b''         b''        b''   \n233   b'Passing'        b''       b''      b''         b''        b''   \n234   b'Passing'        b''       b''      b''         b''        b''   \n235   b'Passing'        b''       b''      b''         b''        b''   \n236   b'Passing'        b''       b''      b''         b''        b''   \n\n               str_filename str_genus str_number str_op_code str_period  \\\n0    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n1    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n2    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n3    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n4    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n..                      ...       ...        ...         ...        ...   \n232  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n233  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n234  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n235  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n236  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n\n    str_species str_stage  \n0           b''     b'AD'  \n1           b''     b'AD'  \n2           b''     b'AD'  \n3           b''     b'AD'  \n4           b''     b'AD'  \n..          ...       ...  \n232         b''     b'AD'  \n233         b''     b'AD'  \n234         b''     b'AD'  \n235         b''     b'AD'  \n236         b''     b'AD'  \n\n[237 rows x 20 columns]",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>d_imx</th>\n      <th>d_imy</th>\n      <th>d_period_time_mins</th>\n      <th>d_rectx</th>\n      <th>d_recty</th>\n      <th>d_time_mins</th>\n      <th>n_frame</th>\n      <th>str_activity</th>\n      <th>str_att_10</th>\n      <th>str_att_9</th>\n      <th>str_code</th>\n      <th>str_comment</th>\n      <th>str_family</th>\n      <th>str_filename</th>\n      <th>str_genus</th>\n      <th>str_number</th>\n      <th>str_op_code</th>\n      <th>str_period</th>\n      <th>str_species</th>\n      <th>str_stage</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>767</td>\n      <td>420</td>\n      <td>-1</td>\n      <td>108</td>\n      <td>77</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>374</td>\n      <td>579</td>\n      <td>-1</td>\n      <td>290</td>\n      <td>137</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>191</td>\n      <td>407</td>\n      <td>-1</td>\n      <td>65</td>\n      <td>27</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>659</td>\n      <td>388</td>\n      <td>-1</td>\n      <td>27</td>\n      <td>21</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>648</td>\n      <td>533</td>\n      <td>-1</td>\n      <td>360</td>\n      <td>145</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>...</th>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n    </tr>\n    <tr>\n      <th>232</th>\n      <td>969</td>\n      <td>787</td>\n      <td>-1</td>\n      <td>399</td>\n      <td>215</td>\n      <td>9.902671</td>\n      <td>17807</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>233</th>\n      <td>678</td>\n      <td>449</td>\n      <td>-1</td>\n      <td>57</td>\n      <td>41</td>\n      <td>9.902671</td>\n      <td>17807</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>234</th>\n      <td>912</td>\n      <td>271</td>\n      <td>-1</td>\n      <td>306</td>\n      <td>153</td>\n      <td>9.999434</td>\n      <td>17981</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>235</th>\n      <td>938</td>\n      <td>411</td>\n      <td>-1</td>\n      <td>122</td>\n      <td>89</td>\n      <td>9.999434</td>\n      <td>17981</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>236</th>\n      <td>951</td>\n      <td>764</td>\n      <td>-1</td>\n      <td>279</td>\n      <td>269</td>\n      <td>9.999434</td>\n      <td>17981</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n  </tbody>\n</table>\n<p>237 rows × 20 columns</p>\n</div>"
+      "text/plain": "   d_imx  d_imy  d_period_time_mins  d_rectx  d_recty  d_time_mins  n_frame  \\\n0    767    420                  -1      108       77     3.868865     6957   \n1    374    579                  -1      290      137     3.868865     6957   \n2    191    407                  -1       65       27     3.868865     6957   \n3    659    388                  -1       27       21     3.868865     6957   \n4    648    533                  -1      360      145     3.868865     6957   \n\n  str_activity str_att_10 str_att_9 str_code str_comment str_family  \\\n0   b'Passing'        b''       b''      b''         b''        b''   \n1   b'Passing'        b''       b''      b''         b''        b''   \n2   b'Passing'        b''       b''      b''         b''        b''   \n3   b'Passing'        b''       b''      b''         b''        b''   \n4   b'Passing'        b''       b''      b''         b''        b''   \n\n             str_filename str_genus str_number str_op_code str_period  \\\n0  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n1  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n2  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n3  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n4  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n\n  str_species str_stage  \n0         b''     b'AD'  \n1         b''     b'AD'  \n2         b''     b'AD'  \n3         b''     b'AD'  \n4         b''     b'AD'  ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>d_imx</th>\n      <th>d_imy</th>\n      <th>d_period_time_mins</th>\n      <th>d_rectx</th>\n      <th>d_recty</th>\n      <th>d_time_mins</th>\n      <th>n_frame</th>\n      <th>str_activity</th>\n      <th>str_att_10</th>\n      <th>str_att_9</th>\n      <th>str_code</th>\n      <th>str_comment</th>\n      <th>str_family</th>\n      <th>str_filename</th>\n      <th>str_genus</th>\n      <th>str_number</th>\n      <th>str_op_code</th>\n      <th>str_period</th>\n      <th>str_species</th>\n      <th>str_stage</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>767</td>\n      <td>420</td>\n      <td>-1</td>\n      <td>108</td>\n      <td>77</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>374</td>\n      <td>579</td>\n      <td>-1</td>\n      <td>290</td>\n      <td>137</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>191</td>\n      <td>407</td>\n      <td>-1</td>\n      <td>65</td>\n      <td>27</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>659</td>\n      <td>388</td>\n      <td>-1</td>\n      <td>27</td>\n      <td>21</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>648</td>\n      <td>533</td>\n      <td>-1</td>\n      <td>360</td>\n      <td>145</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
-     "execution_count": 49,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "boxdf = pdf[pdf['d_rectx'] >= 0]\n",
-    "boxdf"
+    "boxdf.head()"
    ],
    "metadata": {
     "collapsed": false,
@@ -437,10 +383,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 76,
    "outputs": [],
    "source": [
-    "def em_box_coords_to_yolo(x: float, y: float, box_width: float, box_height: float, image_width: float=1920, image_height: float=1080):\n",
+    "def em_box_coords_to_yolo(x: float, y: float, box_width: float, box_height: float, image_width: float=1920, image_height: float=1080) -> namedtuple:\n",
     "    \"\"\"\n",
     "    Helper function to transform the EventMeasure coord to yolo coords.\n",
     "    YOLO coordinates are x, y, centre of the box and all coords normalised by image width and height\n",
@@ -471,20 +417,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0546875\n"
-     ]
-    }
-   ],
-   "source": [
-    "r = em_box_coords_to_yolo(100, 200, 10, 20)\n",
-    "print(r.x)"
-   ],
+   "execution_count": 76,
+   "outputs": [],
+   "source": [],
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -494,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 77,
    "outputs": [],
    "source": [
     "def df_to_yolo(df: pd.DataFrame, out_dir='train', image_width=1920, image_height=1080):\n",
@@ -530,13 +465,7 @@
     "            row_string.append(f\"{label_num} {r.x} {r.y} {r.width} {r.height}\")\n",
     "\n",
     "            print(f'Writing :: {row_string}')\n",
-    "            f.write(f'{row_string[0]}\\n'.encode())\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n"
+    "            f.write(f'{row_string[0]}\\n'.encode())"
    ],
    "metadata": {
     "collapsed": false,
@@ -547,250 +476,250 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 78,
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Unique Labels :: ['Lethrinidae_Lethrinus_punctulatus', 'Lutjanidae_Lutjanus_sebae', '__']\n",
-      "Writing :: ['2 0.4276041666666667 0.42453703703703705 0.05625 0.0712962962962963']\n",
-      "Writing :: ['2 0.2703125 0.5995370370370371 0.15104166666666666 0.12685185185185185']\n",
-      "Writing :: ['2 0.11640625 0.38935185185185184 0.033854166666666664 0.025']\n",
-      "Writing :: ['2 0.3502604166666667 0.36898148148148147 0.0140625 0.019444444444444445']\n",
-      "Writing :: ['2 0.43125 0.5606481481481481 0.1875 0.13425925925925927']\n",
-      "Writing :: ['2 0.15260416666666668 0.4583333333333333 0.028125 0.040740740740740744']\n",
-      "Writing :: ['2 0.7776041666666667 0.4708333333333333 0.027083333333333334 0.030555555555555555']\n",
-      "Writing :: ['2 0.40859375 0.42268518518518516 0.06927083333333334 0.0712962962962963']\n",
-      "Writing :: ['2 0.14583333333333334 0.38796296296296295 0.034375 0.024074074074074074']\n",
-      "Writing :: ['2 0.453125 0.5569444444444445 0.16770833333333332 0.12129629629629629']\n",
-      "Writing :: ['2 0.27838541666666666 0.6018518518518519 0.1484375 0.12777777777777777']\n",
-      "Writing :: ['2 0.33567708333333335 0.41898148148148145 0.0578125 0.06018518518518518']\n",
-      "Writing :: ['2 0.3151041666666667 0.6060185185185185 0.13229166666666667 0.1287037037037037']\n",
-      "Writing :: ['2 0.23463541666666668 0.3787037037037037 0.018229166666666668 0.024074074074074074']\n",
-      "Writing :: ['2 0.4765625 0.5569444444444445 0.11875 0.11018518518518519']\n",
-      "Writing :: ['2 0.33229166666666665 0.37777777777777777 0.023958333333333335 0.02962962962962963']\n",
-      "Writing :: ['2 0.3234375 0.34444444444444444 0.014583333333333334 0.025925925925925925']\n",
-      "Writing :: ['2 0.6213541666666667 0.41759259259259257 0.020833333333333332 0.018518518518518517']\n",
-      "Writing :: ['2 0.20338541666666668 0.5125 0.04010416666666667 0.026851851851851852']\n",
-      "Writing :: ['2 0.3302083333333333 0.6194444444444445 0.146875 0.12962962962962962']\n",
-      "Writing :: ['2 0.359375 0.3458333333333333 0.03229166666666667 0.030555555555555555']\n",
-      "Writing :: ['2 0.29583333333333334 0.4203703703703704 0.05520833333333333 0.05555555555555555']\n",
-      "Writing :: ['2 0.22916666666666666 0.3680555555555556 0.03229166666666667 0.026851851851851852']\n",
-      "Writing :: ['2 0.27578125 0.34444444444444444 0.019270833333333334 0.025925925925925925']\n",
-      "Writing :: ['2 0.6859375 0.47685185185185186 0.042708333333333334 0.025925925925925925']\n",
-      "Writing :: ['2 0.28020833333333334 0.42592592592592593 0.05416666666666667 0.05555555555555555']\n",
-      "Writing :: ['2 0.38203125 0.37037037037037035 0.0328125 0.03518518518518519']\n",
-      "Writing :: ['2 0.2109375 0.37453703703703706 0.0375 0.030555555555555555']\n",
-      "Writing :: ['2 0.27291666666666664 0.34814814814814815 0.01875 0.02962962962962963']\n",
-      "Writing :: ['2 0.34140625 0.6263888888888889 0.11822916666666666 0.11018518518518519']\n",
-      "Writing :: ['2 0.31875 0.38472222222222224 0.030208333333333334 0.028703703703703703']\n",
-      "Writing :: ['2 0.42916666666666664 0.4013888888888889 0.026041666666666668 0.026851851851851852']\n",
-      "Writing :: ['2 0.19791666666666666 0.38472222222222224 0.03125 0.026851851851851852']\n",
-      "Writing :: ['2 0.38333333333333336 0.6171296296296296 0.075 0.10648148148148148']\n",
-      "Writing :: ['2 0.27760416666666665 0.674537037037037 0.20104166666666667 0.15833333333333333']\n",
-      "Writing :: ['2 0.190625 0.38425925925925924 0.020833333333333332 0.024074074074074074']\n",
-      "Writing :: ['2 0.8395833333333333 0.4773148148148148 0.041666666666666664 0.026851851851851852']\n",
-      "Writing :: ['2 0.3609375 0.4185185185185185 0.014583333333333334 0.03518518518518519']\n",
-      "Writing :: ['2 0.5247395833333334 0.41759259259259257 0.034895833333333334 0.02962962962962963']\n",
-      "Writing :: ['2 0.11458333333333333 0.3699074074074074 0.03958333333333333 0.03425925925925926']\n",
-      "Writing :: ['2 0.365625 0.399537037037037 0.016666666666666666 0.03796296296296296']\n",
-      "Writing :: ['2 0.34479166666666666 0.3439814814814815 0.020833333333333332 0.019444444444444445']\n",
-      "Writing :: ['2 0.4354166666666667 0.4634259259259259 0.014583333333333334 0.017592592592592594']\n",
-      "Writing :: ['2 0.2953125 0.663425925925926 0.19583333333333333 0.1675925925925926']\n",
-      "Writing :: ['2 0.7104166666666667 0.4912037037037037 0.034375 0.023148148148148147']\n",
-      "Writing :: ['2 0.4122395833333333 0.39537037037037037 0.013020833333333334 0.022222222222222223']\n",
-      "Writing :: ['2 0.44427083333333334 0.600462962962963 0.109375 0.12685185185185185']\n",
-      "Writing :: ['2 0.29296875 0.3912037037037037 0.0140625 0.017592592592592594']\n",
-      "Writing :: ['2 0.496875 0.5212962962962963 0.04895833333333333 0.06481481481481481']\n",
-      "Writing :: ['2 0.8015625 0.36342592592592593 0.025 0.025']\n",
-      "Writing :: ['2 0.6036458333333333 0.4462962962962963 0.029166666666666667 0.06851851851851852']\n",
-      "Writing :: ['2 0.7604166666666666 0.4462962962962963 0.04375 0.027777777777777776']\n",
-      "Writing :: ['2 0.65546875 0.41759259259259257 0.0203125 0.046296296296296294']\n",
-      "Writing :: ['2 0.7729166666666667 0.40694444444444444 0.015625 0.026851851851851852']\n",
-      "Writing :: ['2 0.5239583333333333 0.5356481481481481 0.05520833333333333 0.11388888888888889']\n",
-      "Writing :: ['2 0.56953125 0.4615740740740741 0.07447916666666667 0.1712962962962963']\n",
-      "Writing :: ['2 0.4466145833333333 0.5907407407407408 0.0609375 0.09444444444444444']\n",
-      "Writing :: ['2 0.7794270833333333 0.43657407407407406 0.0265625 0.03611111111111111']\n",
-      "Writing :: ['2 0.80625 0.36203703703703705 0.019791666666666666 0.037037037037037035']\n",
-      "Writing :: ['2 0.55234375 0.36527777777777776 0.021354166666666667 0.03981481481481482']\n",
-      "Writing :: ['2 0.765625 0.39305555555555555 0.028125 0.03425925925925926']\n",
-      "Writing :: ['2 0.46822916666666664 0.5694444444444444 0.03854166666666667 0.11481481481481481']\n",
-      "Writing :: ['2 0.5255208333333333 0.5291666666666667 0.042708333333333334 0.09351851851851851']\n",
-      "Writing :: ['2 0.6419270833333334 0.3875 0.021354166666666667 0.030555555555555555']\n",
-      "Writing :: ['2 0.6109375 0.4564814814814815 0.028125 0.05185185185185185']\n",
-      "Writing :: ['2 0.48333333333333334 0.41898148148148145 0.01875 0.017592592592592594']\n",
-      "Writing :: ['2 0.48072916666666665 0.4388888888888889 0.021875 0.020370370370370372']\n",
-      "Writing :: ['2 0.5098958333333333 0.40185185185185185 0.016666666666666666 0.020370370370370372']\n",
-      "Writing :: ['2 0.5466145833333333 0.45231481481481484 0.0203125 0.028703703703703703']\n",
-      "Writing :: ['2 0.43203125 0.40370370370370373 0.0109375 0.012962962962962963']\n",
-      "Writing :: ['2 0.0578125 0.32731481481481484 0.01875 0.021296296296296296']\n",
-      "Writing :: ['2 0.40703125 0.3939814814814815 0.008854166666666666 0.017592592592592594']\n",
-      "Writing :: ['2 0.5419270833333333 0.3990740740740741 0.028645833333333332 0.027777777777777776']\n",
-      "Writing :: ['2 0.72421875 0.35 0.0515625 0.04259259259259259']\n",
-      "Writing :: ['2 0.6536458333333334 0.3365740740740741 0.03958333333333333 0.04351851851851852']\n",
-      "Writing :: ['2 0.38619791666666664 0.41759259259259257 0.04739583333333333 0.02962962962962963']\n",
-      "Writing :: ['2 0.809375 0.4101851851851852 0.041666666666666664 0.03148148148148148']\n",
-      "Writing :: ['2 0.6453125 0.46064814814814814 0.15104166666666666 0.13796296296296295']\n",
-      "Writing :: ['2 0.5546875 0.3425925925925926 0.03854166666666667 0.02962962962962963']\n",
-      "Writing :: ['2 0.4973958333333333 0.36018518518518516 0.027083333333333334 0.024074074074074074']\n",
-      "Writing :: ['2 0.4546875 0.375 0.04583333333333333 0.027777777777777776']\n",
-      "Writing :: ['2 0.4192708333333333 0.4601851851851852 0.034375 0.02962962962962963']\n",
-      "Writing :: ['2 0.5088541666666667 0.5356481481481481 0.11145833333333334 0.19907407407407407']\n",
-      "Writing :: ['2 0.5606770833333333 0.2953703703703704 0.0109375 0.03518518518518519']\n",
-      "Writing :: ['2 0.659375 0.3189814814814815 0.03229166666666667 0.025']\n",
-      "Writing :: ['2 0.6174479166666667 0.34444444444444444 0.0234375 0.024074074074074074']\n",
-      "Writing :: ['2 0.63046875 0.3402777777777778 0.03697916666666667 0.049074074074074076']\n",
-      "Writing :: ['2 0.3028645833333333 0.34814814814814815 0.0265625 0.024074074074074074']\n",
-      "Writing :: ['2 0.11015625 0.38055555555555554 0.1328125 0.10555555555555556']\n",
-      "Writing :: ['2 0.6984375 0.3902777777777778 0.053125 0.049074074074074076']\n",
-      "Writing :: ['2 0.4505208333333333 0.2388888888888889 0.03333333333333333 0.03333333333333333']\n",
-      "Writing :: ['2 0.4234375 0.30462962962962964 0.051041666666666666 0.053703703703703705']\n",
-      "Writing :: ['2 0.4002604166666667 0.37222222222222223 0.0328125 0.03518518518518519']\n",
-      "Writing :: ['2 0.33567708333333335 0.37222222222222223 0.024479166666666666 0.018518518518518517']\n",
-      "Writing :: ['2 0.40729166666666666 0.41944444444444445 0.04583333333333333 0.046296296296296294']\n",
-      "Writing :: ['2 0.5372395833333333 0.44907407407407407 0.03177083333333333 0.03333333333333333']\n",
-      "Writing :: ['2 0.378125 0.3199074074074074 0.041666666666666664 0.04351851851851852']\n",
-      "Writing :: ['2 0.6028645833333334 0.4537037037037037 0.021354166666666667 0.020370370370370372']\n",
-      "Writing :: ['2 0.7533854166666667 0.49074074074074076 0.0359375 0.025925925925925925']\n",
-      "Writing :: ['2 0.3848958333333333 0.43333333333333335 0.0125 0.04814814814814815']\n",
-      "Writing :: ['2 0.43411458333333336 0.3425925925925926 0.028645833333333332 0.025925925925925925']\n",
-      "Writing :: ['2 0.6341145833333334 0.4217592592592593 0.04010416666666667 0.03981481481481482']\n",
-      "Writing :: ['2 0.34348958333333335 0.6337962962962963 0.16302083333333334 0.16944444444444445']\n",
-      "Writing :: ['2 0.7018229166666666 0.5060185185185185 0.027604166666666666 0.025']\n",
-      "Writing :: ['2 0.7106770833333333 0.4527777777777778 0.013020833333333334 0.03333333333333333']\n",
-      "Writing :: ['2 0.3419270833333333 0.46620370370370373 0.027604166666666666 0.05277777777777778']\n",
-      "Writing :: ['2 0.35885416666666664 0.4356481481481482 0.022916666666666665 0.021296296296296296']\n",
-      "Writing :: ['2 0.24661458333333333 0.425 0.0234375 0.020370370370370372']\n",
-      "Writing :: ['2 0.4265625 0.4583333333333333 0.014583333333333334 0.027777777777777776']\n",
-      "Writing :: ['2 0.42942708333333335 0.36712962962962964 0.033854166666666664 0.026851851851851852']\n",
-      "Writing :: ['2 0.19947916666666668 0.34675925925925927 0.041666666666666664 0.03425925925925926']\n",
-      "Writing :: ['2 0.7953125 0.46064814814814814 0.030208333333333334 0.025']\n",
-      "Writing :: ['2 0.49635416666666665 0.3574074074074074 0.013541666666666667 0.024074074074074074']\n",
-      "Writing :: ['2 0.20703125 0.36666666666666664 0.028645833333333332 0.027777777777777776']\n",
-      "Writing :: ['2 0.5963541666666666 0.39861111111111114 0.0125 0.017592592592592594']\n",
-      "Writing :: ['2 0.36484375 0.3824074074074074 0.013020833333333334 0.016666666666666666']\n",
-      "Writing :: ['2 0.7453125 0.4546296296296296 0.029166666666666667 0.022222222222222223']\n",
-      "Writing :: ['2 0.9872395833333333 0.40925925925925927 0.024479166666666666 0.03333333333333333']\n",
-      "Writing :: ['2 0.44192708333333336 0.4527777777777778 0.018229166666666668 0.044444444444444446']\n",
-      "Writing :: ['2 0.3640625 0.29583333333333334 0.016666666666666666 0.026851851851851852']\n",
-      "Writing :: ['2 0.8966145833333333 0.5120370370370371 0.013020833333333334 0.03148148148148148']\n",
-      "Writing :: ['2 0.5328125 0.38425925925925924 0.013541666666666667 0.024074074074074074']\n",
-      "Writing :: ['2 0.6466145833333333 0.4486111111111111 0.03697916666666667 0.049074074074074076']\n",
-      "Writing :: ['2 0.2635416666666667 0.35462962962962963 0.04479166666666667 0.046296296296296294']\n",
-      "Writing :: ['2 0.77578125 0.46064814814814814 0.09114583333333333 0.07685185185185185']\n",
-      "Writing :: ['2 0.215625 0.4791666666666667 0.04791666666666667 0.0712962962962963']\n",
-      "Writing :: ['2 0.49296875 0.49675925925925923 0.15260416666666668 0.13425925925925927']\n",
-      "Writing :: ['2 0.26536458333333335 0.49398148148148147 0.04635416666666667 0.05462962962962963']\n",
-      "Writing :: ['2 0.6403645833333333 0.274537037037037 0.027604166666666666 0.025']\n",
-      "Writing :: ['2 0.5497395833333333 0.2912037037037037 0.0328125 0.023148148148148147']\n",
-      "Writing :: ['2 0.8526041666666667 0.4203703703703704 0.028125 0.05185185185185185']\n",
-      "Writing :: ['2 0.3377604166666667 0.34814814814814815 0.030729166666666665 0.024074074074074074']\n",
-      "Writing :: ['2 0.8416666666666667 0.5055555555555555 0.046875 0.027777777777777776']\n",
-      "Writing :: ['2 0.20989583333333334 0.6162037037037037 0.06770833333333333 0.03796296296296296']\n",
-      "Writing :: ['2 0.6869791666666667 0.38796296296296295 0.059375 0.05925925925925926']\n",
-      "Writing :: ['2 0.41432291666666665 0.38472222222222224 0.0390625 0.032407407407407406']\n",
-      "Writing :: ['2 0.4856770833333333 0.3199074074074074 0.018229166666666668 0.028703703703703703']\n",
-      "Writing :: ['2 0.3302083333333333 0.4148148148148148 0.023958333333333335 0.022222222222222223']\n",
-      "Writing :: ['2 0.06848958333333334 0.43703703703703706 0.05364583333333333 0.044444444444444446']\n",
-      "Writing :: ['2 0.8690104166666667 0.3768518518518518 0.05260416666666667 0.02962962962962963']\n",
-      "Writing :: ['2 0.765625 0.3365740740740741 0.017708333333333333 0.023148148148148147']\n",
-      "Writing :: ['2 0.4010416666666667 0.6449074074074074 0.17395833333333333 0.1527777777777778']\n",
-      "Writing :: ['2 0.61484375 0.37407407407407406 0.0234375 0.037037037037037035']\n",
-      "Writing :: ['2 0.13333333333333333 0.362962962962963 0.04479166666666667 0.05']\n",
-      "Writing :: ['2 0.36041666666666666 0.3106481481481482 0.011458333333333333 0.021296296296296296']\n",
-      "Writing :: ['2 0.4869791666666667 0.38055555555555554 0.0125 0.014814814814814815']\n",
-      "Writing :: ['2 0.3768229166666667 0.3990740740740741 0.0171875 0.027777777777777776']\n",
-      "Writing :: ['2 0.37005208333333334 0.3527777777777778 0.011979166666666667 0.014814814814814815']\n",
-      "Writing :: ['2 0.5408854166666667 0.4449074074074074 0.03802083333333333 0.030555555555555555']\n",
-      "Writing :: ['2 0.9466145833333334 0.4587962962962963 0.018229166666666668 0.017592592592592594']\n",
-      "Writing :: ['2 0.3645833333333333 0.4351851851851852 0.03125 0.024074074074074074']\n",
-      "Writing :: ['2 0.3307291666666667 0.31666666666666665 0.015625 0.020370370370370372']\n",
-      "Writing :: ['2 0.39427083333333335 0.4212962962962963 0.014583333333333334 0.024074074074074074']\n",
-      "Writing :: ['2 0.5984375 0.27037037037037037 0.011458333333333333 0.027777777777777776']\n",
-      "Writing :: ['2 0.6861979166666666 0.3476851851851852 0.0109375 0.013888888888888888']\n",
-      "Writing :: ['2 0.8703125 0.30972222222222223 0.01875 0.026851851851851852']\n",
-      "Writing :: ['2 0.4739583333333333 0.37546296296296294 0.013541666666666667 0.01574074074074074']\n",
-      "Writing :: ['2 0.39869791666666665 0.4398148148148148 0.0234375 0.020370370370370372']\n",
-      "Writing :: ['2 0.30442708333333335 0.38055555555555554 0.018229166666666668 0.022222222222222223']\n",
-      "Writing :: ['2 0.28203125 0.3347222222222222 0.013020833333333334 0.013888888888888888']\n",
-      "Writing :: ['2 0.8104166666666667 0.4787037037037037 0.03958333333333333 0.03888888888888889']\n",
-      "Writing :: ['2 0.41432291666666665 0.31712962962962965 0.009895833333333333 0.021296296296296296']\n",
-      "Writing :: ['2 0.4901041666666667 0.3486111111111111 0.011458333333333333 0.01574074074074074']\n",
-      "Writing :: ['2 0.47161458333333334 0.41388888888888886 0.050520833333333334 0.05']\n",
-      "Writing :: ['2 0.6643229166666667 0.4625 0.0328125 0.049074074074074076']\n",
-      "Writing :: ['2 0.7950520833333333 0.45925925925925926 0.08802083333333334 0.06851851851851852']\n",
-      "Writing :: ['1 0.23619791666666667 0.337037037037037 0.06197916666666667 0.044444444444444446']\n",
-      "Writing :: ['2 0.12760416666666666 0.3851851851851852 0.058333333333333334 0.046296296296296294']\n",
-      "Writing :: ['1 0.5434895833333333 0.2935185185185185 0.030729166666666665 0.024074074074074074']\n",
-      "Writing :: ['1 0.22526041666666666 0.45092592592592595 0.034895833333333334 0.05555555555555555']\n",
-      "Writing :: ['2 0.33984375 0.4148148148148148 0.024479166666666666 0.022222222222222223']\n",
-      "Writing :: ['0 0.49635416666666665 0.4930555555555556 0.15416666666666667 0.14537037037037037']\n",
-      "Writing :: ['2 0.48463541666666665 0.3175925925925926 0.022395833333333334 0.027777777777777776']\n",
-      "Writing :: ['1 0.8859375 0.38101851851851853 0.05520833333333333 0.030555555555555555']\n",
-      "Writing :: ['2 0.8640625 0.5078703703703704 0.052083333333333336 0.030555555555555555']\n",
-      "Writing :: ['2 0.6921875 0.387037037037037 0.052083333333333336 0.05740740740740741']\n",
-      "Writing :: ['2 0.35572916666666665 0.43796296296296294 0.029166666666666667 0.025925925925925925']\n",
-      "Writing :: ['2 0.6354166666666666 0.27361111111111114 0.03125 0.023148148148148147']\n",
-      "Writing :: ['2 0.40130208333333334 0.42314814814814816 0.0171875 0.020370370370370372']\n",
-      "Writing :: ['2 0.1109375 0.5856481481481481 0.06458333333333334 0.06018518518518518']\n",
-      "Writing :: ['2 0.3484375 0.3490740740740741 0.030208333333333334 0.024074074074074074']\n",
-      "Writing :: ['2 0.4393229166666667 0.3912037037037037 0.0265625 0.030555555555555555']\n",
-      "Writing :: ['2 0.2981770833333333 0.3851851851851852 0.022395833333333334 0.020370370370370372']\n",
-      "Writing :: ['0 0.39947916666666666 0.6453703703703704 0.16875 0.1537037037037037']\n",
-      "Writing :: ['2 0.55 0.44027777777777777 0.03958333333333333 0.026851851851851852']\n",
-      "Writing :: ['2 0.07083333333333333 0.45601851851851855 0.040625 0.05648148148148148']\n",
-      "Writing :: ['2 0.41458333333333336 0.3125 0.014583333333333334 0.025']\n",
-      "Writing :: ['2 0.32890625 0.32175925925925924 0.0109375 0.026851851851851852']\n",
-      "Writing :: ['2 0.6817708333333333 0.35185185185185186 0.011458333333333333 0.016666666666666666']\n",
-      "Writing :: ['2 0.6078125 0.38101851851851853 0.017708333333333333 0.028703703703703703']\n",
-      "Writing :: ['2 0.375 0.40185185185185185 0.0125 0.024074074074074074']\n",
-      "Writing :: ['2 0.36171875 0.30925925925925923 0.013020833333333334 0.022222222222222223']\n",
-      "Writing :: ['2 0.6786458333333333 0.4236111111111111 0.0125 0.019444444444444445']\n",
-      "Writing :: ['2 0.86015625 0.43657407407407406 0.0296875 0.05277777777777778']\n",
-      "Writing :: ['2 0.4236979166666667 0.4046296296296296 0.0171875 0.020370370370370372']\n",
-      "Writing :: ['2 0.8705729166666667 0.30416666666666664 0.018229166666666668 0.03425925925925926']\n",
-      "Writing :: ['2 0.81640625 0.48703703703703705 0.0328125 0.03888888888888889']\n",
-      "Writing :: ['2 0.47994791666666664 0.4111111111111111 0.04635416666666667 0.046296296296296294']\n",
-      "Writing :: ['2 0.045572916666666664 0.44814814814814813 0.030729166666666665 0.027777777777777776']\n",
-      "Writing :: ['2 0.5994791666666667 0.27824074074074073 0.009375 0.028703703703703703']\n",
-      "Writing :: ['2 0.42291666666666666 0.36944444444444446 0.014583333333333334 0.014814814814814815']\n",
-      "Writing :: ['2 0.9518229166666666 0.46574074074074073 0.016145833333333335 0.020370370370370372']\n",
-      "Writing :: ['2 0.33645833333333336 0.43472222222222223 0.0125 0.013888888888888888']\n",
-      "Writing :: ['2 0.9604166666666667 0.4837962962962963 0.03333333333333333 0.023148148148148147']\n",
-      "Writing :: ['2 0.1421875 0.500462962962963 0.0875 0.04537037037037037']\n",
-      "Writing :: ['2 0.41848958333333336 0.42962962962962964 0.0203125 0.022222222222222223']\n",
-      "Writing :: ['2 0.28072916666666664 0.33240740740740743 0.0125 0.014814814814814815']\n",
-      "Writing :: ['2 0.12083333333333333 0.35185185185185186 0.04583333333333333 0.03888888888888889']\n",
-      "Writing :: ['2 0.18697916666666667 0.387037037037037 0.022916666666666665 0.020370370370370372']\n",
-      "Writing :: ['2 0.3380208333333333 0.2912037037037037 0.04583333333333333 0.1361111111111111']\n",
-      "Writing :: ['2 0.5815104166666667 0.5148148148148148 0.09322916666666667 0.1037037037037037']\n",
-      "Writing :: ['2 0.51796875 0.5 0.07447916666666667 0.07962962962962963']\n",
-      "Writing :: ['2 0.42942708333333335 0.40925925925925927 0.03177083333333333 0.06111111111111111']\n",
-      "Writing :: ['2 0.39010416666666664 0.6564814814814814 0.16979166666666667 0.15925925925925927']\n",
-      "Writing :: ['2 0.5309895833333333 0.40879629629629627 0.0328125 0.04351851851851852']\n",
-      "Writing :: ['2 0.34765625 0.3300925925925926 0.05572916666666667 0.1287037037037037']\n",
-      "Writing :: ['2 0.36380208333333336 0.6810185185185185 0.2078125 0.16944444444444445']\n",
-      "Writing :: ['2 0.43385416666666665 0.2935185185185185 0.17395833333333333 0.17777777777777778']\n",
-      "Writing :: ['2 0.2981770833333333 0.3662037037037037 0.1328125 0.09722222222222222']\n",
-      "Writing :: ['2 0.39296875 0.4287037037037037 0.03802083333333333 0.037037037037037035']\n",
-      "Writing :: ['2 0.6140625 0.836574074074074 0.19583333333333333 0.19537037037037036']\n",
-      "Writing :: ['2 0.65625 0.36064814814814816 0.052083333333333336 0.058333333333333334']\n",
-      "Writing :: ['2 0.60078125 0.47453703703703703 0.0671875 0.08425925925925926']\n",
-      "Writing :: ['2 0.45234375 0.28888888888888886 0.17864583333333334 0.18703703703703703']\n",
-      "Writing :: ['2 0.33125 0.36157407407407405 0.13229166666666667 0.09351851851851851']\n",
-      "Writing :: ['2 0.6171875 0.46574074074074073 0.06145833333333333 0.08148148148148149']\n",
-      "Writing :: ['2 0.60859375 0.8314814814814815 0.2046875 0.19814814814814816']\n",
-      "Writing :: ['2 0.6486979166666667 0.3578703703703704 0.0484375 0.05462962962962963']\n",
-      "Writing :: ['2 0.38776041666666666 0.42916666666666664 0.03802083333333333 0.03981481481481482']\n",
-      "Writing :: ['2 0.45026041666666666 0.3476851851851852 0.12135416666666667 0.10092592592592593']\n",
-      "Writing :: ['2 0.5736979166666667 0.24722222222222223 0.2598958333333333 0.2222222222222222']\n",
-      "Writing :: ['2 0.6473958333333333 0.45555555555555555 0.05625 0.07222222222222222']\n",
-      "Writing :: ['2 0.60859375 0.8282407407407407 0.2078125 0.19907407407407407']\n",
-      "Writing :: ['2 0.36796875 0.43472222222222223 0.0296875 0.03796296296296296']\n",
-      "Writing :: ['2 0.5546875 0.32175925925925924 0.159375 0.14166666666666666']\n",
-      "Writing :: ['2 0.5203125 0.4217592592592593 0.06354166666666666 0.0824074074074074']\n",
-      "Writing :: ['2 0.56796875 0.8319444444444445 0.1453125 0.2490740740740741']\n"
+      "Unique Labels :: ['Lutjanidae_Lutjanus_sebae', '__', 'Lethrinidae_Lethrinus_punctulatus']\n",
+      "Writing :: ['1 0.4276041666666667 0.42453703703703705 0.05625 0.0712962962962963']\n",
+      "Writing :: ['1 0.2703125 0.5995370370370371 0.15104166666666666 0.12685185185185185']\n",
+      "Writing :: ['1 0.11640625 0.38935185185185184 0.033854166666666664 0.025']\n",
+      "Writing :: ['1 0.3502604166666667 0.36898148148148147 0.0140625 0.019444444444444445']\n",
+      "Writing :: ['1 0.43125 0.5606481481481481 0.1875 0.13425925925925927']\n",
+      "Writing :: ['1 0.15260416666666668 0.4583333333333333 0.028125 0.040740740740740744']\n",
+      "Writing :: ['1 0.7776041666666667 0.4708333333333333 0.027083333333333334 0.030555555555555555']\n",
+      "Writing :: ['1 0.40859375 0.42268518518518516 0.06927083333333334 0.0712962962962963']\n",
+      "Writing :: ['1 0.14583333333333334 0.38796296296296295 0.034375 0.024074074074074074']\n",
+      "Writing :: ['1 0.453125 0.5569444444444445 0.16770833333333332 0.12129629629629629']\n",
+      "Writing :: ['1 0.27838541666666666 0.6018518518518519 0.1484375 0.12777777777777777']\n",
+      "Writing :: ['1 0.33567708333333335 0.41898148148148145 0.0578125 0.06018518518518518']\n",
+      "Writing :: ['1 0.3151041666666667 0.6060185185185185 0.13229166666666667 0.1287037037037037']\n",
+      "Writing :: ['1 0.23463541666666668 0.3787037037037037 0.018229166666666668 0.024074074074074074']\n",
+      "Writing :: ['1 0.4765625 0.5569444444444445 0.11875 0.11018518518518519']\n",
+      "Writing :: ['1 0.33229166666666665 0.37777777777777777 0.023958333333333335 0.02962962962962963']\n",
+      "Writing :: ['1 0.3234375 0.34444444444444444 0.014583333333333334 0.025925925925925925']\n",
+      "Writing :: ['1 0.6213541666666667 0.41759259259259257 0.020833333333333332 0.018518518518518517']\n",
+      "Writing :: ['1 0.20338541666666668 0.5125 0.04010416666666667 0.026851851851851852']\n",
+      "Writing :: ['1 0.3302083333333333 0.6194444444444445 0.146875 0.12962962962962962']\n",
+      "Writing :: ['1 0.359375 0.3458333333333333 0.03229166666666667 0.030555555555555555']\n",
+      "Writing :: ['1 0.29583333333333334 0.4203703703703704 0.05520833333333333 0.05555555555555555']\n",
+      "Writing :: ['1 0.22916666666666666 0.3680555555555556 0.03229166666666667 0.026851851851851852']\n",
+      "Writing :: ['1 0.27578125 0.34444444444444444 0.019270833333333334 0.025925925925925925']\n",
+      "Writing :: ['1 0.6859375 0.47685185185185186 0.042708333333333334 0.025925925925925925']\n",
+      "Writing :: ['1 0.28020833333333334 0.42592592592592593 0.05416666666666667 0.05555555555555555']\n",
+      "Writing :: ['1 0.38203125 0.37037037037037035 0.0328125 0.03518518518518519']\n",
+      "Writing :: ['1 0.2109375 0.37453703703703706 0.0375 0.030555555555555555']\n",
+      "Writing :: ['1 0.27291666666666664 0.34814814814814815 0.01875 0.02962962962962963']\n",
+      "Writing :: ['1 0.34140625 0.6263888888888889 0.11822916666666666 0.11018518518518519']\n",
+      "Writing :: ['1 0.31875 0.38472222222222224 0.030208333333333334 0.028703703703703703']\n",
+      "Writing :: ['1 0.42916666666666664 0.4013888888888889 0.026041666666666668 0.026851851851851852']\n",
+      "Writing :: ['1 0.19791666666666666 0.38472222222222224 0.03125 0.026851851851851852']\n",
+      "Writing :: ['1 0.38333333333333336 0.6171296296296296 0.075 0.10648148148148148']\n",
+      "Writing :: ['1 0.27760416666666665 0.674537037037037 0.20104166666666667 0.15833333333333333']\n",
+      "Writing :: ['1 0.190625 0.38425925925925924 0.020833333333333332 0.024074074074074074']\n",
+      "Writing :: ['1 0.8395833333333333 0.4773148148148148 0.041666666666666664 0.026851851851851852']\n",
+      "Writing :: ['1 0.3609375 0.4185185185185185 0.014583333333333334 0.03518518518518519']\n",
+      "Writing :: ['1 0.5247395833333334 0.41759259259259257 0.034895833333333334 0.02962962962962963']\n",
+      "Writing :: ['1 0.11458333333333333 0.3699074074074074 0.03958333333333333 0.03425925925925926']\n",
+      "Writing :: ['1 0.365625 0.399537037037037 0.016666666666666666 0.03796296296296296']\n",
+      "Writing :: ['1 0.34479166666666666 0.3439814814814815 0.020833333333333332 0.019444444444444445']\n",
+      "Writing :: ['1 0.4354166666666667 0.4634259259259259 0.014583333333333334 0.017592592592592594']\n",
+      "Writing :: ['1 0.2953125 0.663425925925926 0.19583333333333333 0.1675925925925926']\n",
+      "Writing :: ['1 0.7104166666666667 0.4912037037037037 0.034375 0.023148148148148147']\n",
+      "Writing :: ['1 0.4122395833333333 0.39537037037037037 0.013020833333333334 0.022222222222222223']\n",
+      "Writing :: ['1 0.44427083333333334 0.600462962962963 0.109375 0.12685185185185185']\n",
+      "Writing :: ['1 0.29296875 0.3912037037037037 0.0140625 0.017592592592592594']\n",
+      "Writing :: ['1 0.496875 0.5212962962962963 0.04895833333333333 0.06481481481481481']\n",
+      "Writing :: ['1 0.8015625 0.36342592592592593 0.025 0.025']\n",
+      "Writing :: ['1 0.6036458333333333 0.4462962962962963 0.029166666666666667 0.06851851851851852']\n",
+      "Writing :: ['1 0.7604166666666666 0.4462962962962963 0.04375 0.027777777777777776']\n",
+      "Writing :: ['1 0.65546875 0.41759259259259257 0.0203125 0.046296296296296294']\n",
+      "Writing :: ['1 0.7729166666666667 0.40694444444444444 0.015625 0.026851851851851852']\n",
+      "Writing :: ['1 0.5239583333333333 0.5356481481481481 0.05520833333333333 0.11388888888888889']\n",
+      "Writing :: ['1 0.56953125 0.4615740740740741 0.07447916666666667 0.1712962962962963']\n",
+      "Writing :: ['1 0.4466145833333333 0.5907407407407408 0.0609375 0.09444444444444444']\n",
+      "Writing :: ['1 0.7794270833333333 0.43657407407407406 0.0265625 0.03611111111111111']\n",
+      "Writing :: ['1 0.80625 0.36203703703703705 0.019791666666666666 0.037037037037037035']\n",
+      "Writing :: ['1 0.55234375 0.36527777777777776 0.021354166666666667 0.03981481481481482']\n",
+      "Writing :: ['1 0.765625 0.39305555555555555 0.028125 0.03425925925925926']\n",
+      "Writing :: ['1 0.46822916666666664 0.5694444444444444 0.03854166666666667 0.11481481481481481']\n",
+      "Writing :: ['1 0.5255208333333333 0.5291666666666667 0.042708333333333334 0.09351851851851851']\n",
+      "Writing :: ['1 0.6419270833333334 0.3875 0.021354166666666667 0.030555555555555555']\n",
+      "Writing :: ['1 0.6109375 0.4564814814814815 0.028125 0.05185185185185185']\n",
+      "Writing :: ['1 0.48333333333333334 0.41898148148148145 0.01875 0.017592592592592594']\n",
+      "Writing :: ['1 0.48072916666666665 0.4388888888888889 0.021875 0.020370370370370372']\n",
+      "Writing :: ['1 0.5098958333333333 0.40185185185185185 0.016666666666666666 0.020370370370370372']\n",
+      "Writing :: ['1 0.5466145833333333 0.45231481481481484 0.0203125 0.028703703703703703']\n",
+      "Writing :: ['1 0.43203125 0.40370370370370373 0.0109375 0.012962962962962963']\n",
+      "Writing :: ['1 0.0578125 0.32731481481481484 0.01875 0.021296296296296296']\n",
+      "Writing :: ['1 0.40703125 0.3939814814814815 0.008854166666666666 0.017592592592592594']\n",
+      "Writing :: ['1 0.5419270833333333 0.3990740740740741 0.028645833333333332 0.027777777777777776']\n",
+      "Writing :: ['1 0.72421875 0.35 0.0515625 0.04259259259259259']\n",
+      "Writing :: ['1 0.6536458333333334 0.3365740740740741 0.03958333333333333 0.04351851851851852']\n",
+      "Writing :: ['1 0.38619791666666664 0.41759259259259257 0.04739583333333333 0.02962962962962963']\n",
+      "Writing :: ['1 0.809375 0.4101851851851852 0.041666666666666664 0.03148148148148148']\n",
+      "Writing :: ['1 0.6453125 0.46064814814814814 0.15104166666666666 0.13796296296296295']\n",
+      "Writing :: ['1 0.5546875 0.3425925925925926 0.03854166666666667 0.02962962962962963']\n",
+      "Writing :: ['1 0.4973958333333333 0.36018518518518516 0.027083333333333334 0.024074074074074074']\n",
+      "Writing :: ['1 0.4546875 0.375 0.04583333333333333 0.027777777777777776']\n",
+      "Writing :: ['1 0.4192708333333333 0.4601851851851852 0.034375 0.02962962962962963']\n",
+      "Writing :: ['1 0.5088541666666667 0.5356481481481481 0.11145833333333334 0.19907407407407407']\n",
+      "Writing :: ['1 0.5606770833333333 0.2953703703703704 0.0109375 0.03518518518518519']\n",
+      "Writing :: ['1 0.659375 0.3189814814814815 0.03229166666666667 0.025']\n",
+      "Writing :: ['1 0.6174479166666667 0.34444444444444444 0.0234375 0.024074074074074074']\n",
+      "Writing :: ['1 0.63046875 0.3402777777777778 0.03697916666666667 0.049074074074074076']\n",
+      "Writing :: ['1 0.3028645833333333 0.34814814814814815 0.0265625 0.024074074074074074']\n",
+      "Writing :: ['1 0.11015625 0.38055555555555554 0.1328125 0.10555555555555556']\n",
+      "Writing :: ['1 0.6984375 0.3902777777777778 0.053125 0.049074074074074076']\n",
+      "Writing :: ['1 0.4505208333333333 0.2388888888888889 0.03333333333333333 0.03333333333333333']\n",
+      "Writing :: ['1 0.4234375 0.30462962962962964 0.051041666666666666 0.053703703703703705']\n",
+      "Writing :: ['1 0.4002604166666667 0.37222222222222223 0.0328125 0.03518518518518519']\n",
+      "Writing :: ['1 0.33567708333333335 0.37222222222222223 0.024479166666666666 0.018518518518518517']\n",
+      "Writing :: ['1 0.40729166666666666 0.41944444444444445 0.04583333333333333 0.046296296296296294']\n",
+      "Writing :: ['1 0.5372395833333333 0.44907407407407407 0.03177083333333333 0.03333333333333333']\n",
+      "Writing :: ['1 0.378125 0.3199074074074074 0.041666666666666664 0.04351851851851852']\n",
+      "Writing :: ['1 0.6028645833333334 0.4537037037037037 0.021354166666666667 0.020370370370370372']\n",
+      "Writing :: ['1 0.7533854166666667 0.49074074074074076 0.0359375 0.025925925925925925']\n",
+      "Writing :: ['1 0.3848958333333333 0.43333333333333335 0.0125 0.04814814814814815']\n",
+      "Writing :: ['1 0.43411458333333336 0.3425925925925926 0.028645833333333332 0.025925925925925925']\n",
+      "Writing :: ['1 0.6341145833333334 0.4217592592592593 0.04010416666666667 0.03981481481481482']\n",
+      "Writing :: ['1 0.34348958333333335 0.6337962962962963 0.16302083333333334 0.16944444444444445']\n",
+      "Writing :: ['1 0.7018229166666666 0.5060185185185185 0.027604166666666666 0.025']\n",
+      "Writing :: ['1 0.7106770833333333 0.4527777777777778 0.013020833333333334 0.03333333333333333']\n",
+      "Writing :: ['1 0.3419270833333333 0.46620370370370373 0.027604166666666666 0.05277777777777778']\n",
+      "Writing :: ['1 0.35885416666666664 0.4356481481481482 0.022916666666666665 0.021296296296296296']\n",
+      "Writing :: ['1 0.24661458333333333 0.425 0.0234375 0.020370370370370372']\n",
+      "Writing :: ['1 0.4265625 0.4583333333333333 0.014583333333333334 0.027777777777777776']\n",
+      "Writing :: ['1 0.42942708333333335 0.36712962962962964 0.033854166666666664 0.026851851851851852']\n",
+      "Writing :: ['1 0.19947916666666668 0.34675925925925927 0.041666666666666664 0.03425925925925926']\n",
+      "Writing :: ['1 0.7953125 0.46064814814814814 0.030208333333333334 0.025']\n",
+      "Writing :: ['1 0.49635416666666665 0.3574074074074074 0.013541666666666667 0.024074074074074074']\n",
+      "Writing :: ['1 0.20703125 0.36666666666666664 0.028645833333333332 0.027777777777777776']\n",
+      "Writing :: ['1 0.5963541666666666 0.39861111111111114 0.0125 0.017592592592592594']\n",
+      "Writing :: ['1 0.36484375 0.3824074074074074 0.013020833333333334 0.016666666666666666']\n",
+      "Writing :: ['1 0.7453125 0.4546296296296296 0.029166666666666667 0.022222222222222223']\n",
+      "Writing :: ['1 0.9872395833333333 0.40925925925925927 0.024479166666666666 0.03333333333333333']\n",
+      "Writing :: ['1 0.44192708333333336 0.4527777777777778 0.018229166666666668 0.044444444444444446']\n",
+      "Writing :: ['1 0.3640625 0.29583333333333334 0.016666666666666666 0.026851851851851852']\n",
+      "Writing :: ['1 0.8966145833333333 0.5120370370370371 0.013020833333333334 0.03148148148148148']\n",
+      "Writing :: ['1 0.5328125 0.38425925925925924 0.013541666666666667 0.024074074074074074']\n",
+      "Writing :: ['1 0.6466145833333333 0.4486111111111111 0.03697916666666667 0.049074074074074076']\n",
+      "Writing :: ['1 0.2635416666666667 0.35462962962962963 0.04479166666666667 0.046296296296296294']\n",
+      "Writing :: ['1 0.77578125 0.46064814814814814 0.09114583333333333 0.07685185185185185']\n",
+      "Writing :: ['1 0.215625 0.4791666666666667 0.04791666666666667 0.0712962962962963']\n",
+      "Writing :: ['1 0.49296875 0.49675925925925923 0.15260416666666668 0.13425925925925927']\n",
+      "Writing :: ['1 0.26536458333333335 0.49398148148148147 0.04635416666666667 0.05462962962962963']\n",
+      "Writing :: ['1 0.6403645833333333 0.274537037037037 0.027604166666666666 0.025']\n",
+      "Writing :: ['1 0.5497395833333333 0.2912037037037037 0.0328125 0.023148148148148147']\n",
+      "Writing :: ['1 0.8526041666666667 0.4203703703703704 0.028125 0.05185185185185185']\n",
+      "Writing :: ['1 0.3377604166666667 0.34814814814814815 0.030729166666666665 0.024074074074074074']\n",
+      "Writing :: ['1 0.8416666666666667 0.5055555555555555 0.046875 0.027777777777777776']\n",
+      "Writing :: ['1 0.20989583333333334 0.6162037037037037 0.06770833333333333 0.03796296296296296']\n",
+      "Writing :: ['1 0.6869791666666667 0.38796296296296295 0.059375 0.05925925925925926']\n",
+      "Writing :: ['1 0.41432291666666665 0.38472222222222224 0.0390625 0.032407407407407406']\n",
+      "Writing :: ['1 0.4856770833333333 0.3199074074074074 0.018229166666666668 0.028703703703703703']\n",
+      "Writing :: ['1 0.3302083333333333 0.4148148148148148 0.023958333333333335 0.022222222222222223']\n",
+      "Writing :: ['1 0.06848958333333334 0.43703703703703706 0.05364583333333333 0.044444444444444446']\n",
+      "Writing :: ['1 0.8690104166666667 0.3768518518518518 0.05260416666666667 0.02962962962962963']\n",
+      "Writing :: ['1 0.765625 0.3365740740740741 0.017708333333333333 0.023148148148148147']\n",
+      "Writing :: ['1 0.4010416666666667 0.6449074074074074 0.17395833333333333 0.1527777777777778']\n",
+      "Writing :: ['1 0.61484375 0.37407407407407406 0.0234375 0.037037037037037035']\n",
+      "Writing :: ['1 0.13333333333333333 0.362962962962963 0.04479166666666667 0.05']\n",
+      "Writing :: ['1 0.36041666666666666 0.3106481481481482 0.011458333333333333 0.021296296296296296']\n",
+      "Writing :: ['1 0.4869791666666667 0.38055555555555554 0.0125 0.014814814814814815']\n",
+      "Writing :: ['1 0.3768229166666667 0.3990740740740741 0.0171875 0.027777777777777776']\n",
+      "Writing :: ['1 0.37005208333333334 0.3527777777777778 0.011979166666666667 0.014814814814814815']\n",
+      "Writing :: ['1 0.5408854166666667 0.4449074074074074 0.03802083333333333 0.030555555555555555']\n",
+      "Writing :: ['1 0.9466145833333334 0.4587962962962963 0.018229166666666668 0.017592592592592594']\n",
+      "Writing :: ['1 0.3645833333333333 0.4351851851851852 0.03125 0.024074074074074074']\n",
+      "Writing :: ['1 0.3307291666666667 0.31666666666666665 0.015625 0.020370370370370372']\n",
+      "Writing :: ['1 0.39427083333333335 0.4212962962962963 0.014583333333333334 0.024074074074074074']\n",
+      "Writing :: ['1 0.5984375 0.27037037037037037 0.011458333333333333 0.027777777777777776']\n",
+      "Writing :: ['1 0.6861979166666666 0.3476851851851852 0.0109375 0.013888888888888888']\n",
+      "Writing :: ['1 0.8703125 0.30972222222222223 0.01875 0.026851851851851852']\n",
+      "Writing :: ['1 0.4739583333333333 0.37546296296296294 0.013541666666666667 0.01574074074074074']\n",
+      "Writing :: ['1 0.39869791666666665 0.4398148148148148 0.0234375 0.020370370370370372']\n",
+      "Writing :: ['1 0.30442708333333335 0.38055555555555554 0.018229166666666668 0.022222222222222223']\n",
+      "Writing :: ['1 0.28203125 0.3347222222222222 0.013020833333333334 0.013888888888888888']\n",
+      "Writing :: ['1 0.8104166666666667 0.4787037037037037 0.03958333333333333 0.03888888888888889']\n",
+      "Writing :: ['1 0.41432291666666665 0.31712962962962965 0.009895833333333333 0.021296296296296296']\n",
+      "Writing :: ['1 0.4901041666666667 0.3486111111111111 0.011458333333333333 0.01574074074074074']\n",
+      "Writing :: ['1 0.47161458333333334 0.41388888888888886 0.050520833333333334 0.05']\n",
+      "Writing :: ['1 0.6643229166666667 0.4625 0.0328125 0.049074074074074076']\n",
+      "Writing :: ['1 0.7950520833333333 0.45925925925925926 0.08802083333333334 0.06851851851851852']\n",
+      "Writing :: ['0 0.23619791666666667 0.337037037037037 0.06197916666666667 0.044444444444444446']\n",
+      "Writing :: ['1 0.12760416666666666 0.3851851851851852 0.058333333333333334 0.046296296296296294']\n",
+      "Writing :: ['0 0.5434895833333333 0.2935185185185185 0.030729166666666665 0.024074074074074074']\n",
+      "Writing :: ['0 0.22526041666666666 0.45092592592592595 0.034895833333333334 0.05555555555555555']\n",
+      "Writing :: ['1 0.33984375 0.4148148148148148 0.024479166666666666 0.022222222222222223']\n",
+      "Writing :: ['2 0.49635416666666665 0.4930555555555556 0.15416666666666667 0.14537037037037037']\n",
+      "Writing :: ['1 0.48463541666666665 0.3175925925925926 0.022395833333333334 0.027777777777777776']\n",
+      "Writing :: ['0 0.8859375 0.38101851851851853 0.05520833333333333 0.030555555555555555']\n",
+      "Writing :: ['1 0.8640625 0.5078703703703704 0.052083333333333336 0.030555555555555555']\n",
+      "Writing :: ['1 0.6921875 0.387037037037037 0.052083333333333336 0.05740740740740741']\n",
+      "Writing :: ['1 0.35572916666666665 0.43796296296296294 0.029166666666666667 0.025925925925925925']\n",
+      "Writing :: ['1 0.6354166666666666 0.27361111111111114 0.03125 0.023148148148148147']\n",
+      "Writing :: ['1 0.40130208333333334 0.42314814814814816 0.0171875 0.020370370370370372']\n",
+      "Writing :: ['1 0.1109375 0.5856481481481481 0.06458333333333334 0.06018518518518518']\n",
+      "Writing :: ['1 0.3484375 0.3490740740740741 0.030208333333333334 0.024074074074074074']\n",
+      "Writing :: ['1 0.4393229166666667 0.3912037037037037 0.0265625 0.030555555555555555']\n",
+      "Writing :: ['1 0.2981770833333333 0.3851851851851852 0.022395833333333334 0.020370370370370372']\n",
+      "Writing :: ['2 0.39947916666666666 0.6453703703703704 0.16875 0.1537037037037037']\n",
+      "Writing :: ['1 0.55 0.44027777777777777 0.03958333333333333 0.026851851851851852']\n",
+      "Writing :: ['1 0.07083333333333333 0.45601851851851855 0.040625 0.05648148148148148']\n",
+      "Writing :: ['1 0.41458333333333336 0.3125 0.014583333333333334 0.025']\n",
+      "Writing :: ['1 0.32890625 0.32175925925925924 0.0109375 0.026851851851851852']\n",
+      "Writing :: ['1 0.6817708333333333 0.35185185185185186 0.011458333333333333 0.016666666666666666']\n",
+      "Writing :: ['1 0.6078125 0.38101851851851853 0.017708333333333333 0.028703703703703703']\n",
+      "Writing :: ['1 0.375 0.40185185185185185 0.0125 0.024074074074074074']\n",
+      "Writing :: ['1 0.36171875 0.30925925925925923 0.013020833333333334 0.022222222222222223']\n",
+      "Writing :: ['1 0.6786458333333333 0.4236111111111111 0.0125 0.019444444444444445']\n",
+      "Writing :: ['1 0.86015625 0.43657407407407406 0.0296875 0.05277777777777778']\n",
+      "Writing :: ['1 0.4236979166666667 0.4046296296296296 0.0171875 0.020370370370370372']\n",
+      "Writing :: ['1 0.8705729166666667 0.30416666666666664 0.018229166666666668 0.03425925925925926']\n",
+      "Writing :: ['1 0.81640625 0.48703703703703705 0.0328125 0.03888888888888889']\n",
+      "Writing :: ['1 0.47994791666666664 0.4111111111111111 0.04635416666666667 0.046296296296296294']\n",
+      "Writing :: ['1 0.045572916666666664 0.44814814814814813 0.030729166666666665 0.027777777777777776']\n",
+      "Writing :: ['1 0.5994791666666667 0.27824074074074073 0.009375 0.028703703703703703']\n",
+      "Writing :: ['1 0.42291666666666666 0.36944444444444446 0.014583333333333334 0.014814814814814815']\n",
+      "Writing :: ['1 0.9518229166666666 0.46574074074074073 0.016145833333333335 0.020370370370370372']\n",
+      "Writing :: ['1 0.33645833333333336 0.43472222222222223 0.0125 0.013888888888888888']\n",
+      "Writing :: ['1 0.9604166666666667 0.4837962962962963 0.03333333333333333 0.023148148148148147']\n",
+      "Writing :: ['1 0.1421875 0.500462962962963 0.0875 0.04537037037037037']\n",
+      "Writing :: ['1 0.41848958333333336 0.42962962962962964 0.0203125 0.022222222222222223']\n",
+      "Writing :: ['1 0.28072916666666664 0.33240740740740743 0.0125 0.014814814814814815']\n",
+      "Writing :: ['1 0.12083333333333333 0.35185185185185186 0.04583333333333333 0.03888888888888889']\n",
+      "Writing :: ['1 0.18697916666666667 0.387037037037037 0.022916666666666665 0.020370370370370372']\n",
+      "Writing :: ['1 0.3380208333333333 0.2912037037037037 0.04583333333333333 0.1361111111111111']\n",
+      "Writing :: ['1 0.5815104166666667 0.5148148148148148 0.09322916666666667 0.1037037037037037']\n",
+      "Writing :: ['1 0.51796875 0.5 0.07447916666666667 0.07962962962962963']\n",
+      "Writing :: ['1 0.42942708333333335 0.40925925925925927 0.03177083333333333 0.06111111111111111']\n",
+      "Writing :: ['1 0.39010416666666664 0.6564814814814814 0.16979166666666667 0.15925925925925927']\n",
+      "Writing :: ['1 0.5309895833333333 0.40879629629629627 0.0328125 0.04351851851851852']\n",
+      "Writing :: ['1 0.34765625 0.3300925925925926 0.05572916666666667 0.1287037037037037']\n",
+      "Writing :: ['1 0.36380208333333336 0.6810185185185185 0.2078125 0.16944444444444445']\n",
+      "Writing :: ['1 0.43385416666666665 0.2935185185185185 0.17395833333333333 0.17777777777777778']\n",
+      "Writing :: ['1 0.2981770833333333 0.3662037037037037 0.1328125 0.09722222222222222']\n",
+      "Writing :: ['1 0.39296875 0.4287037037037037 0.03802083333333333 0.037037037037037035']\n",
+      "Writing :: ['1 0.6140625 0.836574074074074 0.19583333333333333 0.19537037037037036']\n",
+      "Writing :: ['1 0.65625 0.36064814814814816 0.052083333333333336 0.058333333333333334']\n",
+      "Writing :: ['1 0.60078125 0.47453703703703703 0.0671875 0.08425925925925926']\n",
+      "Writing :: ['1 0.45234375 0.28888888888888886 0.17864583333333334 0.18703703703703703']\n",
+      "Writing :: ['1 0.33125 0.36157407407407405 0.13229166666666667 0.09351851851851851']\n",
+      "Writing :: ['1 0.6171875 0.46574074074074073 0.06145833333333333 0.08148148148148149']\n",
+      "Writing :: ['1 0.60859375 0.8314814814814815 0.2046875 0.19814814814814816']\n",
+      "Writing :: ['1 0.6486979166666667 0.3578703703703704 0.0484375 0.05462962962962963']\n",
+      "Writing :: ['1 0.38776041666666666 0.42916666666666664 0.03802083333333333 0.03981481481481482']\n",
+      "Writing :: ['1 0.45026041666666666 0.3476851851851852 0.12135416666666667 0.10092592592592593']\n",
+      "Writing :: ['1 0.5736979166666667 0.24722222222222223 0.2598958333333333 0.2222222222222222']\n",
+      "Writing :: ['1 0.6473958333333333 0.45555555555555555 0.05625 0.07222222222222222']\n",
+      "Writing :: ['1 0.60859375 0.8282407407407407 0.2078125 0.19907407407407407']\n",
+      "Writing :: ['1 0.36796875 0.43472222222222223 0.0296875 0.03796296296296296']\n",
+      "Writing :: ['1 0.5546875 0.32175925925925924 0.159375 0.14166666666666666']\n",
+      "Writing :: ['1 0.5203125 0.4217592592592593 0.06354166666666666 0.0824074074074074']\n",
+      "Writing :: ['1 0.56796875 0.8319444444444445 0.1453125 0.2490740740740741']\n"
      ]
     }
    ],
@@ -806,255 +735,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 0.4276041666666667 0.42453703703703705 0.05625 0.0712962962962963\r\n",
-      "2 0.2703125 0.5995370370370371 0.15104166666666666 0.12685185185185185\r\n",
-      "2 0.11640625 0.38935185185185184 0.033854166666666664 0.025\r\n",
-      "2 0.3502604166666667 0.36898148148148147 0.0140625 0.019444444444444445\r\n",
-      "2 0.43125 0.5606481481481481 0.1875 0.13425925925925927\r\n",
-      "2 0.15260416666666668 0.4583333333333333 0.028125 0.040740740740740744\r\n",
-      "2 0.7776041666666667 0.4708333333333333 0.027083333333333334 0.030555555555555555\r\n",
-      "2 0.40859375 0.42268518518518516 0.06927083333333334 0.0712962962962963\r\n",
-      "2 0.14583333333333334 0.38796296296296295 0.034375 0.024074074074074074\r\n",
-      "2 0.453125 0.5569444444444445 0.16770833333333332 0.12129629629629629\r\n",
-      "2 0.27838541666666666 0.6018518518518519 0.1484375 0.12777777777777777\r\n",
-      "2 0.33567708333333335 0.41898148148148145 0.0578125 0.06018518518518518\r\n",
-      "2 0.3151041666666667 0.6060185185185185 0.13229166666666667 0.1287037037037037\r\n",
-      "2 0.23463541666666668 0.3787037037037037 0.018229166666666668 0.024074074074074074\r\n",
-      "2 0.4765625 0.5569444444444445 0.11875 0.11018518518518519\r\n",
-      "2 0.33229166666666665 0.37777777777777777 0.023958333333333335 0.02962962962962963\r\n",
-      "2 0.3234375 0.34444444444444444 0.014583333333333334 0.025925925925925925\r\n",
-      "2 0.6213541666666667 0.41759259259259257 0.020833333333333332 0.018518518518518517\r\n",
-      "2 0.20338541666666668 0.5125 0.04010416666666667 0.026851851851851852\r\n",
-      "2 0.3302083333333333 0.6194444444444445 0.146875 0.12962962962962962\r\n",
-      "2 0.359375 0.3458333333333333 0.03229166666666667 0.030555555555555555\r\n",
-      "2 0.29583333333333334 0.4203703703703704 0.05520833333333333 0.05555555555555555\r\n",
-      "2 0.22916666666666666 0.3680555555555556 0.03229166666666667 0.026851851851851852\r\n",
-      "2 0.27578125 0.34444444444444444 0.019270833333333334 0.025925925925925925\r\n",
-      "2 0.6859375 0.47685185185185186 0.042708333333333334 0.025925925925925925\r\n",
-      "2 0.28020833333333334 0.42592592592592593 0.05416666666666667 0.05555555555555555\r\n",
-      "2 0.38203125 0.37037037037037035 0.0328125 0.03518518518518519\r\n",
-      "2 0.2109375 0.37453703703703706 0.0375 0.030555555555555555\r\n",
-      "2 0.27291666666666664 0.34814814814814815 0.01875 0.02962962962962963\r\n",
-      "2 0.34140625 0.6263888888888889 0.11822916666666666 0.11018518518518519\r\n",
-      "2 0.31875 0.38472222222222224 0.030208333333333334 0.028703703703703703\r\n",
-      "2 0.42916666666666664 0.4013888888888889 0.026041666666666668 0.026851851851851852\r\n",
-      "2 0.19791666666666666 0.38472222222222224 0.03125 0.026851851851851852\r\n",
-      "2 0.38333333333333336 0.6171296296296296 0.075 0.10648148148148148\r\n",
-      "2 0.27760416666666665 0.674537037037037 0.20104166666666667 0.15833333333333333\r\n",
-      "2 0.190625 0.38425925925925924 0.020833333333333332 0.024074074074074074\r\n",
-      "2 0.8395833333333333 0.4773148148148148 0.041666666666666664 0.026851851851851852\r\n",
-      "2 0.3609375 0.4185185185185185 0.014583333333333334 0.03518518518518519\r\n",
-      "2 0.5247395833333334 0.41759259259259257 0.034895833333333334 0.02962962962962963\r\n",
-      "2 0.11458333333333333 0.3699074074074074 0.03958333333333333 0.03425925925925926\r\n",
-      "2 0.365625 0.399537037037037 0.016666666666666666 0.03796296296296296\r\n",
-      "2 0.34479166666666666 0.3439814814814815 0.020833333333333332 0.019444444444444445\r\n",
-      "2 0.4354166666666667 0.4634259259259259 0.014583333333333334 0.017592592592592594\r\n",
-      "2 0.2953125 0.663425925925926 0.19583333333333333 0.1675925925925926\r\n",
-      "2 0.7104166666666667 0.4912037037037037 0.034375 0.023148148148148147\r\n",
-      "2 0.4122395833333333 0.39537037037037037 0.013020833333333334 0.022222222222222223\r\n",
-      "2 0.44427083333333334 0.600462962962963 0.109375 0.12685185185185185\r\n",
-      "2 0.29296875 0.3912037037037037 0.0140625 0.017592592592592594\r\n",
-      "2 0.496875 0.5212962962962963 0.04895833333333333 0.06481481481481481\r\n",
-      "2 0.8015625 0.36342592592592593 0.025 0.025\r\n",
-      "2 0.6036458333333333 0.4462962962962963 0.029166666666666667 0.06851851851851852\r\n",
-      "2 0.7604166666666666 0.4462962962962963 0.04375 0.027777777777777776\r\n",
-      "2 0.65546875 0.41759259259259257 0.0203125 0.046296296296296294\r\n",
-      "2 0.7729166666666667 0.40694444444444444 0.015625 0.026851851851851852\r\n",
-      "2 0.5239583333333333 0.5356481481481481 0.05520833333333333 0.11388888888888889\r\n",
-      "2 0.56953125 0.4615740740740741 0.07447916666666667 0.1712962962962963\r\n",
-      "2 0.4466145833333333 0.5907407407407408 0.0609375 0.09444444444444444\r\n",
-      "2 0.7794270833333333 0.43657407407407406 0.0265625 0.03611111111111111\r\n",
-      "2 0.80625 0.36203703703703705 0.019791666666666666 0.037037037037037035\r\n",
-      "2 0.55234375 0.36527777777777776 0.021354166666666667 0.03981481481481482\r\n",
-      "2 0.765625 0.39305555555555555 0.028125 0.03425925925925926\r\n",
-      "2 0.46822916666666664 0.5694444444444444 0.03854166666666667 0.11481481481481481\r\n",
-      "2 0.5255208333333333 0.5291666666666667 0.042708333333333334 0.09351851851851851\r\n",
-      "2 0.6419270833333334 0.3875 0.021354166666666667 0.030555555555555555\r\n",
-      "2 0.6109375 0.4564814814814815 0.028125 0.05185185185185185\r\n",
-      "2 0.48333333333333334 0.41898148148148145 0.01875 0.017592592592592594\r\n",
-      "2 0.48072916666666665 0.4388888888888889 0.021875 0.020370370370370372\r\n",
-      "2 0.5098958333333333 0.40185185185185185 0.016666666666666666 0.020370370370370372\r\n",
-      "2 0.5466145833333333 0.45231481481481484 0.0203125 0.028703703703703703\r\n",
-      "2 0.43203125 0.40370370370370373 0.0109375 0.012962962962962963\r\n",
-      "2 0.0578125 0.32731481481481484 0.01875 0.021296296296296296\r\n",
-      "2 0.40703125 0.3939814814814815 0.008854166666666666 0.017592592592592594\r\n",
-      "2 0.5419270833333333 0.3990740740740741 0.028645833333333332 0.027777777777777776\r\n",
-      "2 0.72421875 0.35 0.0515625 0.04259259259259259\r\n",
-      "2 0.6536458333333334 0.3365740740740741 0.03958333333333333 0.04351851851851852\r\n",
-      "2 0.38619791666666664 0.41759259259259257 0.04739583333333333 0.02962962962962963\r\n",
-      "2 0.809375 0.4101851851851852 0.041666666666666664 0.03148148148148148\r\n",
-      "2 0.6453125 0.46064814814814814 0.15104166666666666 0.13796296296296295\r\n",
-      "2 0.5546875 0.3425925925925926 0.03854166666666667 0.02962962962962963\r\n",
-      "2 0.4973958333333333 0.36018518518518516 0.027083333333333334 0.024074074074074074\r\n",
-      "2 0.4546875 0.375 0.04583333333333333 0.027777777777777776\r\n",
-      "2 0.4192708333333333 0.4601851851851852 0.034375 0.02962962962962963\r\n",
-      "2 0.5088541666666667 0.5356481481481481 0.11145833333333334 0.19907407407407407\r\n",
-      "2 0.5606770833333333 0.2953703703703704 0.0109375 0.03518518518518519\r\n",
-      "2 0.659375 0.3189814814814815 0.03229166666666667 0.025\r\n",
-      "2 0.6174479166666667 0.34444444444444444 0.0234375 0.024074074074074074\r\n",
-      "2 0.63046875 0.3402777777777778 0.03697916666666667 0.049074074074074076\r\n",
-      "2 0.3028645833333333 0.34814814814814815 0.0265625 0.024074074074074074\r\n",
-      "2 0.11015625 0.38055555555555554 0.1328125 0.10555555555555556\r\n",
-      "2 0.6984375 0.3902777777777778 0.053125 0.049074074074074076\r\n",
-      "2 0.4505208333333333 0.2388888888888889 0.03333333333333333 0.03333333333333333\r\n",
-      "2 0.4234375 0.30462962962962964 0.051041666666666666 0.053703703703703705\r\n",
-      "2 0.4002604166666667 0.37222222222222223 0.0328125 0.03518518518518519\r\n",
-      "2 0.33567708333333335 0.37222222222222223 0.024479166666666666 0.018518518518518517\r\n",
-      "2 0.40729166666666666 0.41944444444444445 0.04583333333333333 0.046296296296296294\r\n",
-      "2 0.5372395833333333 0.44907407407407407 0.03177083333333333 0.03333333333333333\r\n",
-      "2 0.378125 0.3199074074074074 0.041666666666666664 0.04351851851851852\r\n",
-      "2 0.6028645833333334 0.4537037037037037 0.021354166666666667 0.020370370370370372\r\n",
-      "2 0.7533854166666667 0.49074074074074076 0.0359375 0.025925925925925925\r\n",
-      "2 0.3848958333333333 0.43333333333333335 0.0125 0.04814814814814815\r\n",
-      "2 0.43411458333333336 0.3425925925925926 0.028645833333333332 0.025925925925925925\r\n",
-      "2 0.6341145833333334 0.4217592592592593 0.04010416666666667 0.03981481481481482\r\n",
-      "2 0.34348958333333335 0.6337962962962963 0.16302083333333334 0.16944444444444445\r\n",
-      "2 0.7018229166666666 0.5060185185185185 0.027604166666666666 0.025\r\n",
-      "2 0.7106770833333333 0.4527777777777778 0.013020833333333334 0.03333333333333333\r\n",
-      "2 0.3419270833333333 0.46620370370370373 0.027604166666666666 0.05277777777777778\r\n",
-      "2 0.35885416666666664 0.4356481481481482 0.022916666666666665 0.021296296296296296\r\n",
-      "2 0.24661458333333333 0.425 0.0234375 0.020370370370370372\r\n",
-      "2 0.4265625 0.4583333333333333 0.014583333333333334 0.027777777777777776\r\n",
-      "2 0.42942708333333335 0.36712962962962964 0.033854166666666664 0.026851851851851852\r\n",
-      "2 0.19947916666666668 0.34675925925925927 0.041666666666666664 0.03425925925925926\r\n",
-      "2 0.7953125 0.46064814814814814 0.030208333333333334 0.025\r\n",
-      "2 0.49635416666666665 0.3574074074074074 0.013541666666666667 0.024074074074074074\r\n",
-      "2 0.20703125 0.36666666666666664 0.028645833333333332 0.027777777777777776\r\n",
-      "2 0.5963541666666666 0.39861111111111114 0.0125 0.017592592592592594\r\n",
-      "2 0.36484375 0.3824074074074074 0.013020833333333334 0.016666666666666666\r\n",
-      "2 0.7453125 0.4546296296296296 0.029166666666666667 0.022222222222222223\r\n",
-      "2 0.9872395833333333 0.40925925925925927 0.024479166666666666 0.03333333333333333\r\n",
-      "2 0.44192708333333336 0.4527777777777778 0.018229166666666668 0.044444444444444446\r\n",
-      "2 0.3640625 0.29583333333333334 0.016666666666666666 0.026851851851851852\r\n",
-      "2 0.8966145833333333 0.5120370370370371 0.013020833333333334 0.03148148148148148\r\n",
-      "2 0.5328125 0.38425925925925924 0.013541666666666667 0.024074074074074074\r\n",
-      "2 0.6466145833333333 0.4486111111111111 0.03697916666666667 0.049074074074074076\r\n",
-      "2 0.2635416666666667 0.35462962962962963 0.04479166666666667 0.046296296296296294\r\n",
-      "2 0.77578125 0.46064814814814814 0.09114583333333333 0.07685185185185185\r\n",
-      "2 0.215625 0.4791666666666667 0.04791666666666667 0.0712962962962963\r\n",
-      "2 0.49296875 0.49675925925925923 0.15260416666666668 0.13425925925925927\r\n",
-      "2 0.26536458333333335 0.49398148148148147 0.04635416666666667 0.05462962962962963\r\n",
-      "2 0.6403645833333333 0.274537037037037 0.027604166666666666 0.025\r\n",
-      "2 0.5497395833333333 0.2912037037037037 0.0328125 0.023148148148148147\r\n",
-      "2 0.8526041666666667 0.4203703703703704 0.028125 0.05185185185185185\r\n",
-      "2 0.3377604166666667 0.34814814814814815 0.030729166666666665 0.024074074074074074\r\n",
-      "2 0.8416666666666667 0.5055555555555555 0.046875 0.027777777777777776\r\n",
-      "2 0.20989583333333334 0.6162037037037037 0.06770833333333333 0.03796296296296296\r\n",
-      "2 0.6869791666666667 0.38796296296296295 0.059375 0.05925925925925926\r\n",
-      "2 0.41432291666666665 0.38472222222222224 0.0390625 0.032407407407407406\r\n",
-      "2 0.4856770833333333 0.3199074074074074 0.018229166666666668 0.028703703703703703\r\n",
-      "2 0.3302083333333333 0.4148148148148148 0.023958333333333335 0.022222222222222223\r\n",
-      "2 0.06848958333333334 0.43703703703703706 0.05364583333333333 0.044444444444444446\r\n",
-      "2 0.8690104166666667 0.3768518518518518 0.05260416666666667 0.02962962962962963\r\n",
-      "2 0.765625 0.3365740740740741 0.017708333333333333 0.023148148148148147\r\n",
-      "2 0.4010416666666667 0.6449074074074074 0.17395833333333333 0.1527777777777778\r\n",
-      "2 0.61484375 0.37407407407407406 0.0234375 0.037037037037037035\r\n",
-      "2 0.13333333333333333 0.362962962962963 0.04479166666666667 0.05\r\n",
-      "2 0.36041666666666666 0.3106481481481482 0.011458333333333333 0.021296296296296296\r\n",
-      "2 0.4869791666666667 0.38055555555555554 0.0125 0.014814814814814815\r\n",
-      "2 0.3768229166666667 0.3990740740740741 0.0171875 0.027777777777777776\r\n",
-      "2 0.37005208333333334 0.3527777777777778 0.011979166666666667 0.014814814814814815\r\n",
-      "2 0.5408854166666667 0.4449074074074074 0.03802083333333333 0.030555555555555555\r\n",
-      "2 0.9466145833333334 0.4587962962962963 0.018229166666666668 0.017592592592592594\r\n",
-      "2 0.3645833333333333 0.4351851851851852 0.03125 0.024074074074074074\r\n",
-      "2 0.3307291666666667 0.31666666666666665 0.015625 0.020370370370370372\r\n",
-      "2 0.39427083333333335 0.4212962962962963 0.014583333333333334 0.024074074074074074\r\n",
-      "2 0.5984375 0.27037037037037037 0.011458333333333333 0.027777777777777776\r\n",
-      "2 0.6861979166666666 0.3476851851851852 0.0109375 0.013888888888888888\r\n",
-      "2 0.8703125 0.30972222222222223 0.01875 0.026851851851851852\r\n",
-      "2 0.4739583333333333 0.37546296296296294 0.013541666666666667 0.01574074074074074\r\n",
-      "2 0.39869791666666665 0.4398148148148148 0.0234375 0.020370370370370372\r\n",
-      "2 0.30442708333333335 0.38055555555555554 0.018229166666666668 0.022222222222222223\r\n",
-      "2 0.28203125 0.3347222222222222 0.013020833333333334 0.013888888888888888\r\n",
-      "2 0.8104166666666667 0.4787037037037037 0.03958333333333333 0.03888888888888889\r\n",
-      "2 0.41432291666666665 0.31712962962962965 0.009895833333333333 0.021296296296296296\r\n",
-      "2 0.4901041666666667 0.3486111111111111 0.011458333333333333 0.01574074074074074\r\n",
-      "2 0.47161458333333334 0.41388888888888886 0.050520833333333334 0.05\r\n",
-      "2 0.6643229166666667 0.4625 0.0328125 0.049074074074074076\r\n",
-      "2 0.7950520833333333 0.45925925925925926 0.08802083333333334 0.06851851851851852\r\n",
-      "1 0.23619791666666667 0.337037037037037 0.06197916666666667 0.044444444444444446\r\n",
-      "2 0.12760416666666666 0.3851851851851852 0.058333333333333334 0.046296296296296294\r\n",
-      "1 0.5434895833333333 0.2935185185185185 0.030729166666666665 0.024074074074074074\r\n",
-      "1 0.22526041666666666 0.45092592592592595 0.034895833333333334 0.05555555555555555\r\n",
-      "2 0.33984375 0.4148148148148148 0.024479166666666666 0.022222222222222223\r\n",
-      "0 0.49635416666666665 0.4930555555555556 0.15416666666666667 0.14537037037037037\r\n",
-      "2 0.48463541666666665 0.3175925925925926 0.022395833333333334 0.027777777777777776\r\n",
-      "1 0.8859375 0.38101851851851853 0.05520833333333333 0.030555555555555555\r\n",
-      "2 0.8640625 0.5078703703703704 0.052083333333333336 0.030555555555555555\r\n",
-      "2 0.6921875 0.387037037037037 0.052083333333333336 0.05740740740740741\r\n",
-      "2 0.35572916666666665 0.43796296296296294 0.029166666666666667 0.025925925925925925\r\n",
-      "2 0.6354166666666666 0.27361111111111114 0.03125 0.023148148148148147\r\n",
-      "2 0.40130208333333334 0.42314814814814816 0.0171875 0.020370370370370372\r\n",
-      "2 0.1109375 0.5856481481481481 0.06458333333333334 0.06018518518518518\r\n",
-      "2 0.3484375 0.3490740740740741 0.030208333333333334 0.024074074074074074\r\n",
-      "2 0.4393229166666667 0.3912037037037037 0.0265625 0.030555555555555555\r\n",
-      "2 0.2981770833333333 0.3851851851851852 0.022395833333333334 0.020370370370370372\r\n",
-      "0 0.39947916666666666 0.6453703703703704 0.16875 0.1537037037037037\r\n",
-      "2 0.55 0.44027777777777777 0.03958333333333333 0.026851851851851852\r\n",
-      "2 0.07083333333333333 0.45601851851851855 0.040625 0.05648148148148148\r\n",
-      "2 0.41458333333333336 0.3125 0.014583333333333334 0.025\r\n",
-      "2 0.32890625 0.32175925925925924 0.0109375 0.026851851851851852\r\n",
-      "2 0.6817708333333333 0.35185185185185186 0.011458333333333333 0.016666666666666666\r\n",
-      "2 0.6078125 0.38101851851851853 0.017708333333333333 0.028703703703703703\r\n",
-      "2 0.375 0.40185185185185185 0.0125 0.024074074074074074\r\n",
-      "2 0.36171875 0.30925925925925923 0.013020833333333334 0.022222222222222223\r\n",
-      "2 0.6786458333333333 0.4236111111111111 0.0125 0.019444444444444445\r\n",
-      "2 0.86015625 0.43657407407407406 0.0296875 0.05277777777777778\r\n",
-      "2 0.4236979166666667 0.4046296296296296 0.0171875 0.020370370370370372\r\n",
-      "2 0.8705729166666667 0.30416666666666664 0.018229166666666668 0.03425925925925926\r\n",
-      "2 0.81640625 0.48703703703703705 0.0328125 0.03888888888888889\r\n",
-      "2 0.47994791666666664 0.4111111111111111 0.04635416666666667 0.046296296296296294\r\n",
-      "2 0.045572916666666664 0.44814814814814813 0.030729166666666665 0.027777777777777776\r\n",
-      "2 0.5994791666666667 0.27824074074074073 0.009375 0.028703703703703703\r\n",
-      "2 0.42291666666666666 0.36944444444444446 0.014583333333333334 0.014814814814814815\r\n",
-      "2 0.9518229166666666 0.46574074074074073 0.016145833333333335 0.020370370370370372\r\n",
-      "2 0.33645833333333336 0.43472222222222223 0.0125 0.013888888888888888\r\n",
-      "2 0.9604166666666667 0.4837962962962963 0.03333333333333333 0.023148148148148147\r\n",
-      "2 0.1421875 0.500462962962963 0.0875 0.04537037037037037\r\n",
-      "2 0.41848958333333336 0.42962962962962964 0.0203125 0.022222222222222223\r\n",
-      "2 0.28072916666666664 0.33240740740740743 0.0125 0.014814814814814815\r\n",
-      "2 0.12083333333333333 0.35185185185185186 0.04583333333333333 0.03888888888888889\r\n",
-      "2 0.18697916666666667 0.387037037037037 0.022916666666666665 0.020370370370370372\r\n",
-      "2 0.3380208333333333 0.2912037037037037 0.04583333333333333 0.1361111111111111\r\n",
-      "2 0.5815104166666667 0.5148148148148148 0.09322916666666667 0.1037037037037037\r\n",
-      "2 0.51796875 0.5 0.07447916666666667 0.07962962962962963\r\n",
-      "2 0.42942708333333335 0.40925925925925927 0.03177083333333333 0.06111111111111111\r\n",
-      "2 0.39010416666666664 0.6564814814814814 0.16979166666666667 0.15925925925925927\r\n",
-      "2 0.5309895833333333 0.40879629629629627 0.0328125 0.04351851851851852\r\n",
-      "2 0.34765625 0.3300925925925926 0.05572916666666667 0.1287037037037037\r\n",
-      "2 0.36380208333333336 0.6810185185185185 0.2078125 0.16944444444444445\r\n",
-      "2 0.43385416666666665 0.2935185185185185 0.17395833333333333 0.17777777777777778\r\n",
-      "2 0.2981770833333333 0.3662037037037037 0.1328125 0.09722222222222222\r\n",
-      "2 0.39296875 0.4287037037037037 0.03802083333333333 0.037037037037037035\r\n",
-      "2 0.6140625 0.836574074074074 0.19583333333333333 0.19537037037037036\r\n",
-      "2 0.65625 0.36064814814814816 0.052083333333333336 0.058333333333333334\r\n",
-      "2 0.60078125 0.47453703703703703 0.0671875 0.08425925925925926\r\n",
-      "2 0.45234375 0.28888888888888886 0.17864583333333334 0.18703703703703703\r\n",
-      "2 0.33125 0.36157407407407405 0.13229166666666667 0.09351851851851851\r\n",
-      "2 0.6171875 0.46574074074074073 0.06145833333333333 0.08148148148148149\r\n",
-      "2 0.60859375 0.8314814814814815 0.2046875 0.19814814814814816\r\n",
-      "2 0.6486979166666667 0.3578703703703704 0.0484375 0.05462962962962963\r\n",
-      "2 0.38776041666666666 0.42916666666666664 0.03802083333333333 0.03981481481481482\r\n",
-      "2 0.45026041666666666 0.3476851851851852 0.12135416666666667 0.10092592592592593\r\n",
-      "2 0.5736979166666667 0.24722222222222223 0.2598958333333333 0.2222222222222222\r\n",
-      "2 0.6473958333333333 0.45555555555555555 0.05625 0.07222222222222222\r\n",
-      "2 0.60859375 0.8282407407407407 0.2078125 0.19907407407407407\r\n",
-      "2 0.36796875 0.43472222222222223 0.0296875 0.03796296296296296\r\n",
-      "2 0.5546875 0.32175925925925924 0.159375 0.14166666666666666\r\n",
-      "2 0.5203125 0.4217592592592593 0.06354166666666666 0.0824074074074074\r\n",
-      "2 0.56796875 0.8319444444444445 0.1453125 0.2490740740740741\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "!cat train/em_yolo.txt"
-   ],
+   "execution_count": 78,
+   "outputs": [],
+   "source": [],
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -1064,7 +747,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 79,
    "outputs": [],
    "source": [
     "def extract_frames_from_video(video, frame_number):\n",
@@ -1089,7 +772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 80,
    "outputs": [],
    "source": [
     "img = extract_frames_from_video(os.path.join(TEST_FILES_PATH,boxdf['str_filename'].iloc[0].decode('utf-8')), boxdf['n_frame'].iloc[0])"
@@ -1103,13 +786,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 81,
    "outputs": [
     {
      "data": {
       "text/plain": "True"
      },
-     "execution_count": 57,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1138,20 +821,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "(237, 20)"
-     },
-     "execution_count": 58,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "boxdf.shape"
-   ],
+   "execution_count": 81,
+   "outputs": [],
+   "source": [],
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -1161,13 +833,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 82,
    "outputs": [
     {
      "data": {
       "text/plain": "<IntegerArray>\n[ 6957,  6965,  6992,  7012,  7020,  7035,  7338,  7365,  7571,  7577,  7628,\n 10796, 10913, 10916, 11623, 14521, 17780, 17786, 17807, 17981]\nLength: 20, dtype: Int64"
      },
-     "execution_count": 59,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1184,7 +856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 84,
    "outputs": [
     {
      "name": "stdout",
@@ -1197,39 +869,19 @@
       "6992\n",
       "11\n",
       "7012\n",
-      "19\n",
-      "7020\n",
-      "25\n",
-      "7035\n",
-      "30\n",
-      "7338\n",
-      "34\n",
-      "7365\n",
-      "38\n",
-      "7571\n",
-      "49\n",
-      "7577\n",
-      "57\n",
-      "7628\n",
-      "73\n",
-      "10796\n",
-      "86\n",
-      "10913\n",
-      "122\n",
-      "10916\n",
-      "164\n",
-      "11623\n",
-      "209\n",
-      "14521\n",
-      "215\n",
-      "17780\n",
-      "217\n",
-      "17786\n",
-      "223\n",
-      "17807\n",
-      "229\n",
-      "17981\n",
-      "234\n"
+      "19\n"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mKeyboardInterrupt\u001B[0m                         Traceback (most recent call last)",
+      "Input \u001B[0;32mIn [84]\u001B[0m, in \u001B[0;36m<cell line: 1>\u001B[0;34m()\u001B[0m\n\u001B[1;32m      3\u001B[0m ii_loc \u001B[38;5;241m=\u001B[39m pd\u001B[38;5;241m.\u001B[39mIndex(boxdf[\u001B[38;5;124m'\u001B[39m\u001B[38;5;124mn_frame\u001B[39m\u001B[38;5;124m'\u001B[39m])\u001B[38;5;241m.\u001B[39mget_loc(frame)\u001B[38;5;241m.\u001B[39mstart \u001B[38;5;66;03m# slice object\u001B[39;00m\n\u001B[1;32m      4\u001B[0m \u001B[38;5;28mprint\u001B[39m(ii_loc)\n\u001B[0;32m----> 5\u001B[0m img \u001B[38;5;241m=\u001B[39m \u001B[43mextract_frames_from_video\u001B[49m\u001B[43m(\u001B[49m\u001B[43mos\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mpath\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mjoin\u001B[49m\u001B[43m(\u001B[49m\u001B[43mTEST_FILES_PATH\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mboxdf\u001B[49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mstr_filename\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43miloc\u001B[49m\u001B[43m[\u001B[49m\u001B[43mii_loc\u001B[49m\u001B[43m]\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mdecode\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mutf-8\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m)\u001B[49m\u001B[43m)\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mboxdf\u001B[49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mn_frame\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43miloc\u001B[49m\u001B[43m[\u001B[49m\u001B[43mii_loc\u001B[49m\u001B[43m]\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m      6\u001B[0m cv2\u001B[38;5;241m.\u001B[39mimwrite(\u001B[38;5;124mf\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mtrain/\u001B[39m\u001B[38;5;132;01m{\u001B[39;00mboxdf[\u001B[38;5;124m'\u001B[39m\u001B[38;5;124mstr_filename\u001B[39m\u001B[38;5;124m'\u001B[39m]\u001B[38;5;241m.\u001B[39miloc[ii_loc]\u001B[38;5;241m.\u001B[39mdecode(\u001B[38;5;124m'\u001B[39m\u001B[38;5;124mutf-8\u001B[39m\u001B[38;5;124m'\u001B[39m)\u001B[38;5;132;01m}\u001B[39;00m\u001B[38;5;124m_\u001B[39m\u001B[38;5;132;01m{\u001B[39;00mboxdf[\u001B[38;5;124m'\u001B[39m\u001B[38;5;124mn_frame\u001B[39m\u001B[38;5;124m'\u001B[39m]\u001B[38;5;241m.\u001B[39miloc[ii_loc]\u001B[38;5;132;01m}\u001B[39;00m\u001B[38;5;124m.png\u001B[39m\u001B[38;5;124m\"\u001B[39m, img)\n",
+      "Input \u001B[0;32mIn [79]\u001B[0m, in \u001B[0;36mextract_frames_from_video\u001B[0;34m(video, frame_number)\u001B[0m\n\u001B[1;32m      2\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[1;32m      3\u001B[0m \u001B[38;5;124;03mGiven a BRUVS video, extract the frame as a jpg.\u001B[39;00m\n\u001B[1;32m      4\u001B[0m \u001B[38;5;124;03m:param video:\u001B[39;00m\n\u001B[1;32m      5\u001B[0m \u001B[38;5;124;03m:param frame_number:\u001B[39;00m\n\u001B[1;32m      6\u001B[0m \u001B[38;5;124;03m:return:\u001B[39;00m\n\u001B[1;32m      7\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[1;32m      8\u001B[0m vid \u001B[38;5;241m=\u001B[39m cv2\u001B[38;5;241m.\u001B[39mVideoCapture(video)\n\u001B[0;32m----> 9\u001B[0m \u001B[43mvid\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mset\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;241;43m1\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mframe_number\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;241;43m-\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;241;43m1\u001B[39;49m\u001B[43m)\u001B[49m\n\u001B[1;32m     11\u001B[0m ret, image \u001B[38;5;241m=\u001B[39m vid\u001B[38;5;241m.\u001B[39mread()\n\u001B[1;32m     12\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m image\n",
+      "\u001B[0;31mKeyboardInterrupt\u001B[0m: "
      ]
     }
    ],
@@ -1241,6 +893,42 @@
     "    img = extract_frames_from_video(os.path.join(TEST_FILES_PATH, boxdf['str_filename'].iloc[ii_loc].decode('utf-8')), boxdf['n_frame'].iloc[ii_loc])\n",
     "    cv2.imwrite(f\"train/{boxdf['str_filename'].iloc[ii_loc].decode('utf-8')}_{boxdf['n_frame'].iloc[ii_loc]}.png\", img)"
    ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "outputs": [],
+   "source": [],
    "metadata": {
     "collapsed": false,
     "pycharm": {

--- a/src/notebooks/gen_yolo_training_data.ipynb
+++ b/src/notebooks/gen_yolo_training_data.ipynb
@@ -747,7 +747,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 85,
    "outputs": [],
    "source": [
     "def extract_frames_from_video(video, frame_number):\n",
@@ -758,7 +758,7 @@
     "    :return:\n",
     "    \"\"\"\n",
     "    vid = cv2.VideoCapture(video)\n",
-    "    vid.set(1, frame_number - 1)\n",
+    "    vid.set(1, frame_number)\n",
     "\n",
     "    ret, image = vid.read()\n",
     "    return image"

--- a/src/notebooks/gen_yolo_training_data.ipynb
+++ b/src/notebooks/gen_yolo_training_data.ipynb
@@ -1,0 +1,242 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# An example notebook how to generate training data for YOLOv5 from an .EMObs file"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "outputs": [],
+   "source": [
+    "import os, sys\n",
+    "sys.path.append(\"..\")\n",
+    "\n",
+    "import emtmlibpy.emtmlibpy as emtm\n",
+    "from emtmlibpy.emtmlibpy import EMTMResult\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [],
+   "source": [
+    "SRC_DIR = os.path.abspath(os.getcwd())\n",
+    "TEST_FILES_PATH = os.path.join(SRC_DIR, '..', 'test_files')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Sanity check that we can read the library"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(2, 0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(emtm.emtm_version())"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Load the .EMObs files"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [],
+   "source": [
+    "r = emtm.em_load_data(os.path.join(TEST_FILES_PATH, 'Test.EMObs'))\n",
+    "assert EMTMResult(r) == EMTMResult(0)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Load the data in Test.EMObs into a dataframe"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(b'', b'', b''), (b'balistidae', b'abalistes', b'stellatus'), (b'nemipteridae', b'nemipterus', b'furcosus'), (b'nemipteridae', b'pentapodus', b'porosus'), (b'pinguipedidae', b'parapercis', b'xanthozona'), (b'scombridae', b'scomberomorus', b'queenslandicus')]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# this needs to be called first to generate the list\n",
+    "n_fgs = emtm.em_unique_fgs()\n",
+    "fgs = []\n",
+    "\n",
+    "for ii in range(n_fgs):\n",
+    "    fgs.append(emtm.em_get_unique_fgs(ii))\n",
+    "\n",
+    "print(fgs)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "outputs": [],
+   "source": [
+    "def xyz_point_to_df():\n",
+    "    \"\"\"\n",
+    "    Given an EM3DPointData return a pandas dataframe\n",
+    "    :return: a pandas dataframe\n",
+    "    \"\"\"\n",
+    "    point_count = emtm.em_3d_point_count()\n",
+    "    p = emtm.em_get_3d_point(0)\n",
+    "    index = [attr for attr in dir(p) if (not attr.startswith('__') and not attr.startswith('_'))]\n",
+    "    data = np.empty(shape=[point_count, len(index)], dtype='|S1024')  # change these\n",
+    "\n",
+    "    for jj in range(point_count):\n",
+    "        p = emtm.em_get_3d_point(jj)\n",
+    "        for ii, ind in enumerate(index):\n",
+    "            data[jj][ii] = p.__getattribute__(ind)\n",
+    "\n",
+    "    return pd.DataFrame(data=data, columns=index)\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "outputs": [],
+   "source": [
+    "p = xyz_point_to_df()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "             d_direction             d_imx_left           d_imx_right  \\\n0   b'8.441783313318227'   b'743.2100840336134'  b'849.4957983193277'   \n1  b'10.234504387632896'  b'198.15126050420167'  b'630.7563025210084'   \n\n             d_imy_left           d_imy_right d_period_time_mins  \\\n0  b'841.5858208955224'  b'829.6679104477612'            b'-1.0'   \n1  b'556.1194029850747'  b'519.8507462686567'            b'-1.0'   \n\n                 d_range                  d_rms            d_time_mins  \\\n0  b'1955.9342450851996'  b'0.7913513948160356'   b'7.351333333333333'   \n1  b'1238.4819331917604'  b'1.1620835816700836'  b'23.507333333333335'   \n\n                     dsx  ... str_comment        str_family  \\\n0  b'0.8858858156953887'  ...         b''  b'Pinguipedidae'   \n1  b'0.6271794475200771'  ...         b''   b'Nemipteridae'   \n\n    str_filename_left  str_filename_right      str_genus str_number  \\\n0  b'C1_39_Cam23.mpg'  b'C1_39_Cam24.mpg'  b'Parapercis'       b'1'   \n1  b'C1_39_Cam23.mpg'  b'C1_39_Cam24.mpg'  b'Nemipterus'       b'1'   \n\n  str_op_code str_period    str_species str_stage  \n0     b'Test'        b''  b'xanthozona'     b'AD'  \n1     b'Test'        b''    b'furcosus'     b'AD'  \n\n[2 rows x 31 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>d_direction</th>\n      <th>d_imx_left</th>\n      <th>d_imx_right</th>\n      <th>d_imy_left</th>\n      <th>d_imy_right</th>\n      <th>d_period_time_mins</th>\n      <th>d_range</th>\n      <th>d_rms</th>\n      <th>d_time_mins</th>\n      <th>dsx</th>\n      <th>...</th>\n      <th>str_comment</th>\n      <th>str_family</th>\n      <th>str_filename_left</th>\n      <th>str_filename_right</th>\n      <th>str_genus</th>\n      <th>str_number</th>\n      <th>str_op_code</th>\n      <th>str_period</th>\n      <th>str_species</th>\n      <th>str_stage</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>b'8.441783313318227'</td>\n      <td>b'743.2100840336134'</td>\n      <td>b'849.4957983193277'</td>\n      <td>b'841.5858208955224'</td>\n      <td>b'829.6679104477612'</td>\n      <td>b'-1.0'</td>\n      <td>b'1955.9342450851996'</td>\n      <td>b'0.7913513948160356'</td>\n      <td>b'7.351333333333333'</td>\n      <td>b'0.8858858156953887'</td>\n      <td>...</td>\n      <td>b''</td>\n      <td>b'Pinguipedidae'</td>\n      <td>b'C1_39_Cam23.mpg'</td>\n      <td>b'C1_39_Cam24.mpg'</td>\n      <td>b'Parapercis'</td>\n      <td>b'1'</td>\n      <td>b'Test'</td>\n      <td>b''</td>\n      <td>b'xanthozona'</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>b'10.234504387632896'</td>\n      <td>b'198.15126050420167'</td>\n      <td>b'630.7563025210084'</td>\n      <td>b'556.1194029850747'</td>\n      <td>b'519.8507462686567'</td>\n      <td>b'-1.0'</td>\n      <td>b'1238.4819331917604'</td>\n      <td>b'1.1620835816700836'</td>\n      <td>b'23.507333333333335'</td>\n      <td>b'0.6271794475200771'</td>\n      <td>...</td>\n      <td>b''</td>\n      <td>b'Nemipteridae'</td>\n      <td>b'C1_39_Cam23.mpg'</td>\n      <td>b'C1_39_Cam24.mpg'</td>\n      <td>b'Nemipterus'</td>\n      <td>b'1'</td>\n      <td>b'Test'</td>\n      <td>b''</td>\n      <td>b'furcosus'</td>\n      <td>b'AD'</td>\n    </tr>\n  </tbody>\n</table>\n<p>2 rows × 31 columns</p>\n</div>"
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/src/notebooks/gen_yolo_training_data.ipynb
+++ b/src/notebooks/gen_yolo_training_data.ipynb
@@ -494,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 74,
    "outputs": [],
    "source": [
     "def df_to_yolo(df: pd.DataFrame, out_dir='train', image_width=1920, image_height=1080):\n",
@@ -508,17 +508,18 @@
     "    \"\"\"\n",
     "    os.makedirs(out_dir, exist_ok=True)\n",
     "\n",
-    "    with open(os.path.join(out_dir, 'em_yolo.txt'), 'wb') as f:\n",
-    "        label = []\n",
-    "        for index, row in df.iterrows():\n",
-    "            #concatinate fgs for the label name\n",
-    "            label.append(f\"{row['str_family'].decode('utf-8')}_{row['str_genus'].decode('utf-8')}_{row['str_species'].decode('utf-8')}\")\n",
-    "        label = list(set(label))\n",
-    "        print(f'Unique Labels :: {label}')\n",
     "\n",
-    "        # Now we have the unique labels pull them out and create the string format.\n",
+    "    label = []\n",
+    "    for index, row in df.iterrows():\n",
+    "        #concatinate fgs for the label name\n",
+    "        label.append(f\"{row['str_family'].decode('utf-8')}_{row['str_genus'].decode('utf-8')}_{row['str_species'].decode('utf-8')}\")\n",
+    "    label = list(set(label))\n",
+    "    print(f'Unique Labels :: {label}')\n",
     "\n",
-    "        for index, row in df.iterrows():\n",
+    "    # Now we have the unique labels pull them out and create the string format.\n",
+    "\n",
+    "    for index, row in df.iterrows():\n",
+    "        with open(os.path.join(out_dir, f\"{df['str_filename'].iloc[index].decode('utf-8')}_{df['n_frame'].iloc[index]}.txt\"), 'ab') as f:\n",
     "            row_label = []\n",
     "            row_string = []\n",
     "            r = em_box_coords_to_yolo(row['d_imx'], row['d_imy'], row['d_rectx'], row['d_recty'])\n",
@@ -546,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 75,
    "outputs": [
     {
      "name": "stdout",
@@ -1183,7 +1184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 76,
    "outputs": [
     {
      "name": "stdout",
@@ -1238,7 +1239,7 @@
     "    ii_loc = pd.Index(boxdf['n_frame']).get_loc(frame).start # slice object\n",
     "    print(ii_loc)\n",
     "    img = extract_frames_from_video(os.path.join(TEST_FILES_PATH, boxdf['str_filename'].iloc[ii_loc].decode('utf-8')), boxdf['n_frame'].iloc[ii_loc])\n",
-    "    cv2.imwrite(f'train/{frame}_test.png', img)"
+    "    cv2.imwrite(f\"train/{boxdf['str_filename'].iloc[ii_loc].decode('utf-8')}_{boxdf['n_frame'].iloc[ii_loc]}.png\", img)"
    ],
    "metadata": {
     "collapsed": false,

--- a/src/notebooks/gen_yolo_training_data.ipynb
+++ b/src/notebooks/gen_yolo_training_data.ipynb
@@ -14,17 +14,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 35,
    "outputs": [],
    "source": [
     "import os, sys\n",
+    "from typing import Any\n",
+    "import cv2\n",
+    "\n",
+    "from pandas import Series, DataFrame\n",
+    "from pandas.core.generic import NDFrame\n",
+    "\n",
     "sys.path.append(\"..\")\n",
     "\n",
     "import emtmlibpy.emtmlibpy as emtm\n",
     "from emtmlibpy.emtmlibpy import EMTMResult\n",
     "\n",
     "import numpy as np\n",
-    "import pandas as pd\n"
+    "import pandas as pd\n",
+    "from collections import namedtuple\n",
+    "#\n",
+    "\n"
    ],
    "metadata": {
     "collapsed": false,
@@ -35,11 +44,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 36,
    "outputs": [],
    "source": [
     "SRC_DIR = os.path.abspath(os.getcwd())\n",
     "TEST_FILES_PATH = os.path.join(SRC_DIR, '..', 'test_files')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "outputs": [],
+   "source": [
+    "TEST_FILES_PATH = '/home/marrabld/data/test_emobs/emtmlibpy'\n",
+    "TEST_FILE = 'afid.EMObs'"
    ],
    "metadata": {
     "collapsed": false,
@@ -62,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 38,
    "outputs": [
     {
      "name": "stdout",
@@ -96,10 +120,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 39,
    "outputs": [],
    "source": [
-    "r = emtm.em_load_data(os.path.join(TEST_FILES_PATH, 'Test.EMObs'))\n",
+    "r = emtm.em_load_data(os.path.join(TEST_FILES_PATH, TEST_FILE))\n",
     "assert EMTMResult(r) == EMTMResult(0)"
    ],
    "metadata": {
@@ -123,13 +147,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 40,
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[(b'', b'', b''), (b'balistidae', b'abalistes', b'stellatus'), (b'nemipteridae', b'nemipterus', b'furcosus'), (b'nemipteridae', b'pentapodus', b'porosus'), (b'pinguipedidae', b'parapercis', b'xanthozona'), (b'scombridae', b'scomberomorus', b'queenslandicus')]\n"
+      "[(b'', b'', b''), (b'lethrinidae', b'lethrinus', b'punctulatus'), (b'lutjanidae', b'lutjanus', b'sebae')]\n"
      ]
     }
    ],
@@ -152,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 41,
    "outputs": [],
    "source": [
     "def xyz_point_to_df():\n",
@@ -181,10 +205,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 41,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
    "outputs": [],
    "source": [
-    "p = xyz_point_to_df()"
+    "xyz_p = xyz_point_to_df()"
    ],
    "metadata": {
     "collapsed": false,
@@ -195,21 +231,1027 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 43,
    "outputs": [
     {
      "data": {
-      "text/plain": "             d_direction             d_imx_left           d_imx_right  \\\n0   b'8.441783313318227'   b'743.2100840336134'  b'849.4957983193277'   \n1  b'10.234504387632896'  b'198.15126050420167'  b'630.7563025210084'   \n\n             d_imy_left           d_imy_right d_period_time_mins  \\\n0  b'841.5858208955224'  b'829.6679104477612'            b'-1.0'   \n1  b'556.1194029850747'  b'519.8507462686567'            b'-1.0'   \n\n                 d_range                  d_rms            d_time_mins  \\\n0  b'1955.9342450851996'  b'0.7913513948160356'   b'7.351333333333333'   \n1  b'1238.4819331917604'  b'1.1620835816700836'  b'23.507333333333335'   \n\n                     dsx  ... str_comment        str_family  \\\n0  b'0.8858858156953887'  ...         b''  b'Pinguipedidae'   \n1  b'0.6271794475200771'  ...         b''   b'Nemipteridae'   \n\n    str_filename_left  str_filename_right      str_genus str_number  \\\n0  b'C1_39_Cam23.mpg'  b'C1_39_Cam24.mpg'  b'Parapercis'       b'1'   \n1  b'C1_39_Cam23.mpg'  b'C1_39_Cam24.mpg'  b'Nemipterus'       b'1'   \n\n  str_op_code str_period    str_species str_stage  \n0     b'Test'        b''  b'xanthozona'     b'AD'  \n1     b'Test'        b''    b'furcosus'     b'AD'  \n\n[2 rows x 31 columns]",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>d_direction</th>\n      <th>d_imx_left</th>\n      <th>d_imx_right</th>\n      <th>d_imy_left</th>\n      <th>d_imy_right</th>\n      <th>d_period_time_mins</th>\n      <th>d_range</th>\n      <th>d_rms</th>\n      <th>d_time_mins</th>\n      <th>dsx</th>\n      <th>...</th>\n      <th>str_comment</th>\n      <th>str_family</th>\n      <th>str_filename_left</th>\n      <th>str_filename_right</th>\n      <th>str_genus</th>\n      <th>str_number</th>\n      <th>str_op_code</th>\n      <th>str_period</th>\n      <th>str_species</th>\n      <th>str_stage</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>b'8.441783313318227'</td>\n      <td>b'743.2100840336134'</td>\n      <td>b'849.4957983193277'</td>\n      <td>b'841.5858208955224'</td>\n      <td>b'829.6679104477612'</td>\n      <td>b'-1.0'</td>\n      <td>b'1955.9342450851996'</td>\n      <td>b'0.7913513948160356'</td>\n      <td>b'7.351333333333333'</td>\n      <td>b'0.8858858156953887'</td>\n      <td>...</td>\n      <td>b''</td>\n      <td>b'Pinguipedidae'</td>\n      <td>b'C1_39_Cam23.mpg'</td>\n      <td>b'C1_39_Cam24.mpg'</td>\n      <td>b'Parapercis'</td>\n      <td>b'1'</td>\n      <td>b'Test'</td>\n      <td>b''</td>\n      <td>b'xanthozona'</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>b'10.234504387632896'</td>\n      <td>b'198.15126050420167'</td>\n      <td>b'630.7563025210084'</td>\n      <td>b'556.1194029850747'</td>\n      <td>b'519.8507462686567'</td>\n      <td>b'-1.0'</td>\n      <td>b'1238.4819331917604'</td>\n      <td>b'1.1620835816700836'</td>\n      <td>b'23.507333333333335'</td>\n      <td>b'0.6271794475200771'</td>\n      <td>...</td>\n      <td>b''</td>\n      <td>b'Nemipteridae'</td>\n      <td>b'C1_39_Cam23.mpg'</td>\n      <td>b'C1_39_Cam24.mpg'</td>\n      <td>b'Nemipterus'</td>\n      <td>b'1'</td>\n      <td>b'Test'</td>\n      <td>b''</td>\n      <td>b'furcosus'</td>\n      <td>b'AD'</td>\n    </tr>\n  </tbody>\n</table>\n<p>2 rows × 31 columns</p>\n</div>"
+      "text/plain": "Empty DataFrame\nColumns: [d_direction, d_imx_left, d_imx_right, d_imy_left, d_imy_right, d_period_time_mins, d_range, d_rms, d_time_mins, dsx, dsy, dsz, dx, dy, dz, n_frame_left, n_frame_right, str_activity, str_att_10, str_att_9, str_code, str_comment, str_family, str_filename_left, str_filename_right, str_genus, str_number, str_op_code, str_period, str_species, str_stage]\nIndex: []\n\n[0 rows x 31 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>d_direction</th>\n      <th>d_imx_left</th>\n      <th>d_imx_right</th>\n      <th>d_imy_left</th>\n      <th>d_imy_right</th>\n      <th>d_period_time_mins</th>\n      <th>d_range</th>\n      <th>d_rms</th>\n      <th>d_time_mins</th>\n      <th>dsx</th>\n      <th>...</th>\n      <th>str_comment</th>\n      <th>str_family</th>\n      <th>str_filename_left</th>\n      <th>str_filename_right</th>\n      <th>str_genus</th>\n      <th>str_number</th>\n      <th>str_op_code</th>\n      <th>str_period</th>\n      <th>str_species</th>\n      <th>str_stage</th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n<p>0 rows × 31 columns</p>\n</div>"
      },
-     "execution_count": 8,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "p"
+    "xyz_point_to_df()"
    ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "outputs": [],
+   "source": [
+    "def point_to_df():\n",
+    "    \"\"\"\n",
+    "    Convert EvemtMeasure points to a dataframe\n",
+    "    :return: Pandas dataframe\n",
+    "    \"\"\"\n",
+    "    dtype_template = 'object'\n",
+    "    point_count, box_count = emtm.em_point_count()\n",
+    "    print(f'points {point_count}')\n",
+    "    print(f'box {box_count}')\n",
+    "\n",
+    "    p = emtm.em_get_point(0)\n",
+    "    index = [attr for attr in dir(p) if (not attr.startswith('__') and not attr.startswith('_'))]\n",
+    "    print(index)\n",
+    "    data = np.empty(shape=[point_count, len(index)], dtype=dtype_template)  # change these\n",
+    "\n",
+    "    for jj in range(point_count):\n",
+    "        p = emtm.em_get_point(jj)\n",
+    "        for ii, ind in enumerate(index):\n",
+    "            tmp = p.__getattribute__(ind)\n",
+    "            data[jj][ii] = tmp\n",
+    "\n",
+    "    xpdf = pd.DataFrame(data=data, columns=index)\n",
+    "    xpdf = xpdf.convert_dtypes().infer_objects()\n",
+    "    return xpdf\n",
+    "\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "points 237\n",
+      "box 237\n",
+      "['d_imx', 'd_imy', 'd_period_time_mins', 'd_rectx', 'd_recty', 'd_time_mins', 'n_frame', 'str_activity', 'str_att_10', 'str_att_9', 'str_code', 'str_comment', 'str_family', 'str_filename', 'str_genus', 'str_number', 'str_op_code', 'str_period', 'str_species', 'str_stage']\n"
+     ]
+    }
+   ],
+   "source": [
+    "pdf = point_to_df()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "     d_imx  d_imy  d_period_time_mins  d_rectx  d_recty  d_time_mins  n_frame  \\\n0      767    420                  -1      108       77     3.868865     6957   \n1      374    579                  -1      290      137     3.868865     6957   \n2      191    407                  -1       65       27     3.868865     6957   \n3      659    388                  -1       27       21     3.868865     6957   \n4      648    533                  -1      360      145     3.868865     6957   \n..     ...    ...                 ...      ...      ...          ...      ...   \n232    969    787                  -1      399      215     9.902671    17807   \n233    678    449                  -1       57       41     9.902671    17807   \n234    912    271                  -1      306      153     9.999434    17981   \n235    938    411                  -1      122       89     9.999434    17981   \n236    951    764                  -1      279      269     9.999434    17981   \n\n    str_activity str_att_10 str_att_9 str_code str_comment str_family  \\\n0     b'Passing'        b''       b''      b''         b''        b''   \n1     b'Passing'        b''       b''      b''         b''        b''   \n2     b'Passing'        b''       b''      b''         b''        b''   \n3     b'Passing'        b''       b''      b''         b''        b''   \n4     b'Passing'        b''       b''      b''         b''        b''   \n..           ...        ...       ...      ...         ...        ...   \n232   b'Passing'        b''       b''      b''         b''        b''   \n233   b'Passing'        b''       b''      b''         b''        b''   \n234   b'Passing'        b''       b''      b''         b''        b''   \n235   b'Passing'        b''       b''      b''         b''        b''   \n236   b'Passing'        b''       b''      b''         b''        b''   \n\n               str_filename str_genus str_number str_op_code str_period  \\\n0    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n1    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n2    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n3    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n4    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n..                      ...       ...        ...         ...        ...   \n232  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n233  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n234  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n235  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n236  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n\n    str_species str_stage  \n0           b''     b'AD'  \n1           b''     b'AD'  \n2           b''     b'AD'  \n3           b''     b'AD'  \n4           b''     b'AD'  \n..          ...       ...  \n232         b''     b'AD'  \n233         b''     b'AD'  \n234         b''     b'AD'  \n235         b''     b'AD'  \n236         b''     b'AD'  \n\n[237 rows x 20 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>d_imx</th>\n      <th>d_imy</th>\n      <th>d_period_time_mins</th>\n      <th>d_rectx</th>\n      <th>d_recty</th>\n      <th>d_time_mins</th>\n      <th>n_frame</th>\n      <th>str_activity</th>\n      <th>str_att_10</th>\n      <th>str_att_9</th>\n      <th>str_code</th>\n      <th>str_comment</th>\n      <th>str_family</th>\n      <th>str_filename</th>\n      <th>str_genus</th>\n      <th>str_number</th>\n      <th>str_op_code</th>\n      <th>str_period</th>\n      <th>str_species</th>\n      <th>str_stage</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>767</td>\n      <td>420</td>\n      <td>-1</td>\n      <td>108</td>\n      <td>77</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>374</td>\n      <td>579</td>\n      <td>-1</td>\n      <td>290</td>\n      <td>137</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>191</td>\n      <td>407</td>\n      <td>-1</td>\n      <td>65</td>\n      <td>27</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>659</td>\n      <td>388</td>\n      <td>-1</td>\n      <td>27</td>\n      <td>21</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>648</td>\n      <td>533</td>\n      <td>-1</td>\n      <td>360</td>\n      <td>145</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>...</th>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n    </tr>\n    <tr>\n      <th>232</th>\n      <td>969</td>\n      <td>787</td>\n      <td>-1</td>\n      <td>399</td>\n      <td>215</td>\n      <td>9.902671</td>\n      <td>17807</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>233</th>\n      <td>678</td>\n      <td>449</td>\n      <td>-1</td>\n      <td>57</td>\n      <td>41</td>\n      <td>9.902671</td>\n      <td>17807</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>234</th>\n      <td>912</td>\n      <td>271</td>\n      <td>-1</td>\n      <td>306</td>\n      <td>153</td>\n      <td>9.999434</td>\n      <td>17981</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>235</th>\n      <td>938</td>\n      <td>411</td>\n      <td>-1</td>\n      <td>122</td>\n      <td>89</td>\n      <td>9.999434</td>\n      <td>17981</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>236</th>\n      <td>951</td>\n      <td>764</td>\n      <td>-1</td>\n      <td>279</td>\n      <td>269</td>\n      <td>9.999434</td>\n      <td>17981</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n  </tbody>\n</table>\n<p>237 rows × 20 columns</p>\n</div>"
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pdf"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "0       \n1       \n2       \n3       \n4       \n      ..\n232     \n233     \n234     \n235     \n236     \nName: str_family, Length: 237, dtype: object"
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pdf['str_family'].str.decode('utf-8')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 237 entries, 0 to 236\n",
+      "Data columns (total 20 columns):\n",
+      " #   Column              Non-Null Count  Dtype  \n",
+      "---  ------              --------------  -----  \n",
+      " 0   d_imx               237 non-null    Int64  \n",
+      " 1   d_imy               237 non-null    Int64  \n",
+      " 2   d_period_time_mins  237 non-null    Int64  \n",
+      " 3   d_rectx             237 non-null    Int64  \n",
+      " 4   d_recty             237 non-null    Int64  \n",
+      " 5   d_time_mins         237 non-null    Float64\n",
+      " 6   n_frame             237 non-null    Int64  \n",
+      " 7   str_activity        237 non-null    object \n",
+      " 8   str_att_10          237 non-null    object \n",
+      " 9   str_att_9           237 non-null    object \n",
+      " 10  str_code            237 non-null    object \n",
+      " 11  str_comment         237 non-null    object \n",
+      " 12  str_family          237 non-null    object \n",
+      " 13  str_filename        237 non-null    object \n",
+      " 14  str_genus           237 non-null    object \n",
+      " 15  str_number          237 non-null    object \n",
+      " 16  str_op_code         237 non-null    object \n",
+      " 17  str_period          237 non-null    object \n",
+      " 18  str_species         237 non-null    object \n",
+      " 19  str_stage           237 non-null    object \n",
+      "dtypes: Float64(1), Int64(6), object(13)\n",
+      "memory usage: 38.8+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "pdf.info()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "     d_imx  d_imy  d_period_time_mins  d_rectx  d_recty  d_time_mins  n_frame  \\\n0      767    420                  -1      108       77     3.868865     6957   \n1      374    579                  -1      290      137     3.868865     6957   \n2      191    407                  -1       65       27     3.868865     6957   \n3      659    388                  -1       27       21     3.868865     6957   \n4      648    533                  -1      360      145     3.868865     6957   \n..     ...    ...                 ...      ...      ...          ...      ...   \n232    969    787                  -1      399      215     9.902671    17807   \n233    678    449                  -1       57       41     9.902671    17807   \n234    912    271                  -1      306      153     9.999434    17981   \n235    938    411                  -1      122       89     9.999434    17981   \n236    951    764                  -1      279      269     9.999434    17981   \n\n    str_activity str_att_10 str_att_9 str_code str_comment str_family  \\\n0     b'Passing'        b''       b''      b''         b''        b''   \n1     b'Passing'        b''       b''      b''         b''        b''   \n2     b'Passing'        b''       b''      b''         b''        b''   \n3     b'Passing'        b''       b''      b''         b''        b''   \n4     b'Passing'        b''       b''      b''         b''        b''   \n..           ...        ...       ...      ...         ...        ...   \n232   b'Passing'        b''       b''      b''         b''        b''   \n233   b'Passing'        b''       b''      b''         b''        b''   \n234   b'Passing'        b''       b''      b''         b''        b''   \n235   b'Passing'        b''       b''      b''         b''        b''   \n236   b'Passing'        b''       b''      b''         b''        b''   \n\n               str_filename str_genus str_number str_op_code str_period  \\\n0    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n1    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n2    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n3    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n4    b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n..                      ...       ...        ...         ...        ...   \n232  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n233  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n234  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n235  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n236  b'G000048 L_small.m4v'       b''       b'1'     b'AFID'        b''   \n\n    str_species str_stage  \n0           b''     b'AD'  \n1           b''     b'AD'  \n2           b''     b'AD'  \n3           b''     b'AD'  \n4           b''     b'AD'  \n..          ...       ...  \n232         b''     b'AD'  \n233         b''     b'AD'  \n234         b''     b'AD'  \n235         b''     b'AD'  \n236         b''     b'AD'  \n\n[237 rows x 20 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>d_imx</th>\n      <th>d_imy</th>\n      <th>d_period_time_mins</th>\n      <th>d_rectx</th>\n      <th>d_recty</th>\n      <th>d_time_mins</th>\n      <th>n_frame</th>\n      <th>str_activity</th>\n      <th>str_att_10</th>\n      <th>str_att_9</th>\n      <th>str_code</th>\n      <th>str_comment</th>\n      <th>str_family</th>\n      <th>str_filename</th>\n      <th>str_genus</th>\n      <th>str_number</th>\n      <th>str_op_code</th>\n      <th>str_period</th>\n      <th>str_species</th>\n      <th>str_stage</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>767</td>\n      <td>420</td>\n      <td>-1</td>\n      <td>108</td>\n      <td>77</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>374</td>\n      <td>579</td>\n      <td>-1</td>\n      <td>290</td>\n      <td>137</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>191</td>\n      <td>407</td>\n      <td>-1</td>\n      <td>65</td>\n      <td>27</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>659</td>\n      <td>388</td>\n      <td>-1</td>\n      <td>27</td>\n      <td>21</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>648</td>\n      <td>533</td>\n      <td>-1</td>\n      <td>360</td>\n      <td>145</td>\n      <td>3.868865</td>\n      <td>6957</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>...</th>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n    </tr>\n    <tr>\n      <th>232</th>\n      <td>969</td>\n      <td>787</td>\n      <td>-1</td>\n      <td>399</td>\n      <td>215</td>\n      <td>9.902671</td>\n      <td>17807</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>233</th>\n      <td>678</td>\n      <td>449</td>\n      <td>-1</td>\n      <td>57</td>\n      <td>41</td>\n      <td>9.902671</td>\n      <td>17807</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>234</th>\n      <td>912</td>\n      <td>271</td>\n      <td>-1</td>\n      <td>306</td>\n      <td>153</td>\n      <td>9.999434</td>\n      <td>17981</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>235</th>\n      <td>938</td>\n      <td>411</td>\n      <td>-1</td>\n      <td>122</td>\n      <td>89</td>\n      <td>9.999434</td>\n      <td>17981</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n    <tr>\n      <th>236</th>\n      <td>951</td>\n      <td>764</td>\n      <td>-1</td>\n      <td>279</td>\n      <td>269</td>\n      <td>9.999434</td>\n      <td>17981</td>\n      <td>b'Passing'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'G000048 L_small.m4v'</td>\n      <td>b''</td>\n      <td>b'1'</td>\n      <td>b'AFID'</td>\n      <td>b''</td>\n      <td>b''</td>\n      <td>b'AD'</td>\n    </tr>\n  </tbody>\n</table>\n<p>237 rows × 20 columns</p>\n</div>"
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "boxdf = pdf[pdf['d_rectx'] >= 0]\n",
+    "boxdf"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "outputs": [],
+   "source": [
+    "def em_box_coords_to_yolo(x: float, y: float, box_width: float, box_height: float, image_width: float=1920, image_height: float=1080):\n",
+    "    \"\"\"\n",
+    "    Helper function to transform the EventMeasure coord to yolo coords.\n",
+    "    YOLO coordinates are x, y, centre of the box and all coords normalised by image width and height\n",
+    "    :param image_height:\n",
+    "    :param image_width:\n",
+    "    :param box_height:\n",
+    "    :param box_width:\n",
+    "    :param x: Pixel column\n",
+    "    :param y: Pixel row\n",
+    "    :return: namedtuple (x, y, width, height)\n",
+    "    \"\"\"\n",
+    "\n",
+    "    XYWH = namedtuple('XYHW', 'x y width height')\n",
+    "\n",
+    "    yolo_x = (x + box_width / 2) / image_width\n",
+    "    yolo_y = (y + box_height / 2) / image_height\n",
+    "    yolo_box_width = box_width / image_width\n",
+    "    yolo_box_height = box_height / image_height\n",
+    "\n",
+    "    return XYWH(yolo_x, yolo_y, yolo_box_width, yolo_box_height)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.0546875\n"
+     ]
+    }
+   ],
+   "source": [
+    "r = em_box_coords_to_yolo(100, 200, 10, 20)\n",
+    "print(r.x)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "outputs": [],
+   "source": [
+    "def df_to_yolo(df: pd.DataFrame, out_dir='train', image_width=1920, image_height=1080):\n",
+    "    \"\"\"\n",
+    "    Given a data frame write out a directory with training data in the YOLO format\n",
+    "    <object-class> <x> <y> <width> <height>\n",
+    "\n",
+    "    integer number of object from 0 to (classes-1) - float values relative to width and height of image, it can be equal from (0.0 to 1.0] for example: <x> = <absolute_x> / <image_width> or <height> = <absolute_height> / <image_height> atention: <x> <y> - are center of rectangle (are not top-left corner)\n",
+    "    :param df:\n",
+    "    :return:\n",
+    "    \"\"\"\n",
+    "    os.makedirs(out_dir, exist_ok=True)\n",
+    "\n",
+    "    with open(os.path.join(out_dir, 'em_yolo.txt'), 'wb') as f:\n",
+    "        label = []\n",
+    "        for index, row in df.iterrows():\n",
+    "            #concatinate fgs for the label name\n",
+    "            label.append(f\"{row['str_family'].decode('utf-8')}_{row['str_genus'].decode('utf-8')}_{row['str_species'].decode('utf-8')}\")\n",
+    "        label = list(set(label))\n",
+    "        print(f'Unique Labels :: {label}')\n",
+    "\n",
+    "        # Now we have the unique labels pull them out and create the string format.\n",
+    "\n",
+    "        for index, row in df.iterrows():\n",
+    "            row_label = []\n",
+    "            row_string = []\n",
+    "            r = em_box_coords_to_yolo(row['d_imx'], row['d_imy'], row['d_rectx'], row['d_recty'])\n",
+    "            #concatinate fgs for the label name\n",
+    "            row_label = f\"{row['str_family'].decode('utf-8')}_{row['str_genus'].decode('utf-8')}_{row['str_species'].decode('utf-8')}\"\n",
+    "            label_num = label.index(row_label)\n",
+    "            # Add the coordinates and boxes\n",
+    "            row_string.append(f\"{label_num} {r.x} {r.y} {r.width} {r.height}\")\n",
+    "\n",
+    "            print(f'Writing :: {row_string}')\n",
+    "            f.write(f'{row_string[0]}\\n'.encode())\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unique Labels :: ['Lethrinidae_Lethrinus_punctulatus', 'Lutjanidae_Lutjanus_sebae', '__']\n",
+      "Writing :: ['2 0.4276041666666667 0.42453703703703705 0.05625 0.0712962962962963']\n",
+      "Writing :: ['2 0.2703125 0.5995370370370371 0.15104166666666666 0.12685185185185185']\n",
+      "Writing :: ['2 0.11640625 0.38935185185185184 0.033854166666666664 0.025']\n",
+      "Writing :: ['2 0.3502604166666667 0.36898148148148147 0.0140625 0.019444444444444445']\n",
+      "Writing :: ['2 0.43125 0.5606481481481481 0.1875 0.13425925925925927']\n",
+      "Writing :: ['2 0.15260416666666668 0.4583333333333333 0.028125 0.040740740740740744']\n",
+      "Writing :: ['2 0.7776041666666667 0.4708333333333333 0.027083333333333334 0.030555555555555555']\n",
+      "Writing :: ['2 0.40859375 0.42268518518518516 0.06927083333333334 0.0712962962962963']\n",
+      "Writing :: ['2 0.14583333333333334 0.38796296296296295 0.034375 0.024074074074074074']\n",
+      "Writing :: ['2 0.453125 0.5569444444444445 0.16770833333333332 0.12129629629629629']\n",
+      "Writing :: ['2 0.27838541666666666 0.6018518518518519 0.1484375 0.12777777777777777']\n",
+      "Writing :: ['2 0.33567708333333335 0.41898148148148145 0.0578125 0.06018518518518518']\n",
+      "Writing :: ['2 0.3151041666666667 0.6060185185185185 0.13229166666666667 0.1287037037037037']\n",
+      "Writing :: ['2 0.23463541666666668 0.3787037037037037 0.018229166666666668 0.024074074074074074']\n",
+      "Writing :: ['2 0.4765625 0.5569444444444445 0.11875 0.11018518518518519']\n",
+      "Writing :: ['2 0.33229166666666665 0.37777777777777777 0.023958333333333335 0.02962962962962963']\n",
+      "Writing :: ['2 0.3234375 0.34444444444444444 0.014583333333333334 0.025925925925925925']\n",
+      "Writing :: ['2 0.6213541666666667 0.41759259259259257 0.020833333333333332 0.018518518518518517']\n",
+      "Writing :: ['2 0.20338541666666668 0.5125 0.04010416666666667 0.026851851851851852']\n",
+      "Writing :: ['2 0.3302083333333333 0.6194444444444445 0.146875 0.12962962962962962']\n",
+      "Writing :: ['2 0.359375 0.3458333333333333 0.03229166666666667 0.030555555555555555']\n",
+      "Writing :: ['2 0.29583333333333334 0.4203703703703704 0.05520833333333333 0.05555555555555555']\n",
+      "Writing :: ['2 0.22916666666666666 0.3680555555555556 0.03229166666666667 0.026851851851851852']\n",
+      "Writing :: ['2 0.27578125 0.34444444444444444 0.019270833333333334 0.025925925925925925']\n",
+      "Writing :: ['2 0.6859375 0.47685185185185186 0.042708333333333334 0.025925925925925925']\n",
+      "Writing :: ['2 0.28020833333333334 0.42592592592592593 0.05416666666666667 0.05555555555555555']\n",
+      "Writing :: ['2 0.38203125 0.37037037037037035 0.0328125 0.03518518518518519']\n",
+      "Writing :: ['2 0.2109375 0.37453703703703706 0.0375 0.030555555555555555']\n",
+      "Writing :: ['2 0.27291666666666664 0.34814814814814815 0.01875 0.02962962962962963']\n",
+      "Writing :: ['2 0.34140625 0.6263888888888889 0.11822916666666666 0.11018518518518519']\n",
+      "Writing :: ['2 0.31875 0.38472222222222224 0.030208333333333334 0.028703703703703703']\n",
+      "Writing :: ['2 0.42916666666666664 0.4013888888888889 0.026041666666666668 0.026851851851851852']\n",
+      "Writing :: ['2 0.19791666666666666 0.38472222222222224 0.03125 0.026851851851851852']\n",
+      "Writing :: ['2 0.38333333333333336 0.6171296296296296 0.075 0.10648148148148148']\n",
+      "Writing :: ['2 0.27760416666666665 0.674537037037037 0.20104166666666667 0.15833333333333333']\n",
+      "Writing :: ['2 0.190625 0.38425925925925924 0.020833333333333332 0.024074074074074074']\n",
+      "Writing :: ['2 0.8395833333333333 0.4773148148148148 0.041666666666666664 0.026851851851851852']\n",
+      "Writing :: ['2 0.3609375 0.4185185185185185 0.014583333333333334 0.03518518518518519']\n",
+      "Writing :: ['2 0.5247395833333334 0.41759259259259257 0.034895833333333334 0.02962962962962963']\n",
+      "Writing :: ['2 0.11458333333333333 0.3699074074074074 0.03958333333333333 0.03425925925925926']\n",
+      "Writing :: ['2 0.365625 0.399537037037037 0.016666666666666666 0.03796296296296296']\n",
+      "Writing :: ['2 0.34479166666666666 0.3439814814814815 0.020833333333333332 0.019444444444444445']\n",
+      "Writing :: ['2 0.4354166666666667 0.4634259259259259 0.014583333333333334 0.017592592592592594']\n",
+      "Writing :: ['2 0.2953125 0.663425925925926 0.19583333333333333 0.1675925925925926']\n",
+      "Writing :: ['2 0.7104166666666667 0.4912037037037037 0.034375 0.023148148148148147']\n",
+      "Writing :: ['2 0.4122395833333333 0.39537037037037037 0.013020833333333334 0.022222222222222223']\n",
+      "Writing :: ['2 0.44427083333333334 0.600462962962963 0.109375 0.12685185185185185']\n",
+      "Writing :: ['2 0.29296875 0.3912037037037037 0.0140625 0.017592592592592594']\n",
+      "Writing :: ['2 0.496875 0.5212962962962963 0.04895833333333333 0.06481481481481481']\n",
+      "Writing :: ['2 0.8015625 0.36342592592592593 0.025 0.025']\n",
+      "Writing :: ['2 0.6036458333333333 0.4462962962962963 0.029166666666666667 0.06851851851851852']\n",
+      "Writing :: ['2 0.7604166666666666 0.4462962962962963 0.04375 0.027777777777777776']\n",
+      "Writing :: ['2 0.65546875 0.41759259259259257 0.0203125 0.046296296296296294']\n",
+      "Writing :: ['2 0.7729166666666667 0.40694444444444444 0.015625 0.026851851851851852']\n",
+      "Writing :: ['2 0.5239583333333333 0.5356481481481481 0.05520833333333333 0.11388888888888889']\n",
+      "Writing :: ['2 0.56953125 0.4615740740740741 0.07447916666666667 0.1712962962962963']\n",
+      "Writing :: ['2 0.4466145833333333 0.5907407407407408 0.0609375 0.09444444444444444']\n",
+      "Writing :: ['2 0.7794270833333333 0.43657407407407406 0.0265625 0.03611111111111111']\n",
+      "Writing :: ['2 0.80625 0.36203703703703705 0.019791666666666666 0.037037037037037035']\n",
+      "Writing :: ['2 0.55234375 0.36527777777777776 0.021354166666666667 0.03981481481481482']\n",
+      "Writing :: ['2 0.765625 0.39305555555555555 0.028125 0.03425925925925926']\n",
+      "Writing :: ['2 0.46822916666666664 0.5694444444444444 0.03854166666666667 0.11481481481481481']\n",
+      "Writing :: ['2 0.5255208333333333 0.5291666666666667 0.042708333333333334 0.09351851851851851']\n",
+      "Writing :: ['2 0.6419270833333334 0.3875 0.021354166666666667 0.030555555555555555']\n",
+      "Writing :: ['2 0.6109375 0.4564814814814815 0.028125 0.05185185185185185']\n",
+      "Writing :: ['2 0.48333333333333334 0.41898148148148145 0.01875 0.017592592592592594']\n",
+      "Writing :: ['2 0.48072916666666665 0.4388888888888889 0.021875 0.020370370370370372']\n",
+      "Writing :: ['2 0.5098958333333333 0.40185185185185185 0.016666666666666666 0.020370370370370372']\n",
+      "Writing :: ['2 0.5466145833333333 0.45231481481481484 0.0203125 0.028703703703703703']\n",
+      "Writing :: ['2 0.43203125 0.40370370370370373 0.0109375 0.012962962962962963']\n",
+      "Writing :: ['2 0.0578125 0.32731481481481484 0.01875 0.021296296296296296']\n",
+      "Writing :: ['2 0.40703125 0.3939814814814815 0.008854166666666666 0.017592592592592594']\n",
+      "Writing :: ['2 0.5419270833333333 0.3990740740740741 0.028645833333333332 0.027777777777777776']\n",
+      "Writing :: ['2 0.72421875 0.35 0.0515625 0.04259259259259259']\n",
+      "Writing :: ['2 0.6536458333333334 0.3365740740740741 0.03958333333333333 0.04351851851851852']\n",
+      "Writing :: ['2 0.38619791666666664 0.41759259259259257 0.04739583333333333 0.02962962962962963']\n",
+      "Writing :: ['2 0.809375 0.4101851851851852 0.041666666666666664 0.03148148148148148']\n",
+      "Writing :: ['2 0.6453125 0.46064814814814814 0.15104166666666666 0.13796296296296295']\n",
+      "Writing :: ['2 0.5546875 0.3425925925925926 0.03854166666666667 0.02962962962962963']\n",
+      "Writing :: ['2 0.4973958333333333 0.36018518518518516 0.027083333333333334 0.024074074074074074']\n",
+      "Writing :: ['2 0.4546875 0.375 0.04583333333333333 0.027777777777777776']\n",
+      "Writing :: ['2 0.4192708333333333 0.4601851851851852 0.034375 0.02962962962962963']\n",
+      "Writing :: ['2 0.5088541666666667 0.5356481481481481 0.11145833333333334 0.19907407407407407']\n",
+      "Writing :: ['2 0.5606770833333333 0.2953703703703704 0.0109375 0.03518518518518519']\n",
+      "Writing :: ['2 0.659375 0.3189814814814815 0.03229166666666667 0.025']\n",
+      "Writing :: ['2 0.6174479166666667 0.34444444444444444 0.0234375 0.024074074074074074']\n",
+      "Writing :: ['2 0.63046875 0.3402777777777778 0.03697916666666667 0.049074074074074076']\n",
+      "Writing :: ['2 0.3028645833333333 0.34814814814814815 0.0265625 0.024074074074074074']\n",
+      "Writing :: ['2 0.11015625 0.38055555555555554 0.1328125 0.10555555555555556']\n",
+      "Writing :: ['2 0.6984375 0.3902777777777778 0.053125 0.049074074074074076']\n",
+      "Writing :: ['2 0.4505208333333333 0.2388888888888889 0.03333333333333333 0.03333333333333333']\n",
+      "Writing :: ['2 0.4234375 0.30462962962962964 0.051041666666666666 0.053703703703703705']\n",
+      "Writing :: ['2 0.4002604166666667 0.37222222222222223 0.0328125 0.03518518518518519']\n",
+      "Writing :: ['2 0.33567708333333335 0.37222222222222223 0.024479166666666666 0.018518518518518517']\n",
+      "Writing :: ['2 0.40729166666666666 0.41944444444444445 0.04583333333333333 0.046296296296296294']\n",
+      "Writing :: ['2 0.5372395833333333 0.44907407407407407 0.03177083333333333 0.03333333333333333']\n",
+      "Writing :: ['2 0.378125 0.3199074074074074 0.041666666666666664 0.04351851851851852']\n",
+      "Writing :: ['2 0.6028645833333334 0.4537037037037037 0.021354166666666667 0.020370370370370372']\n",
+      "Writing :: ['2 0.7533854166666667 0.49074074074074076 0.0359375 0.025925925925925925']\n",
+      "Writing :: ['2 0.3848958333333333 0.43333333333333335 0.0125 0.04814814814814815']\n",
+      "Writing :: ['2 0.43411458333333336 0.3425925925925926 0.028645833333333332 0.025925925925925925']\n",
+      "Writing :: ['2 0.6341145833333334 0.4217592592592593 0.04010416666666667 0.03981481481481482']\n",
+      "Writing :: ['2 0.34348958333333335 0.6337962962962963 0.16302083333333334 0.16944444444444445']\n",
+      "Writing :: ['2 0.7018229166666666 0.5060185185185185 0.027604166666666666 0.025']\n",
+      "Writing :: ['2 0.7106770833333333 0.4527777777777778 0.013020833333333334 0.03333333333333333']\n",
+      "Writing :: ['2 0.3419270833333333 0.46620370370370373 0.027604166666666666 0.05277777777777778']\n",
+      "Writing :: ['2 0.35885416666666664 0.4356481481481482 0.022916666666666665 0.021296296296296296']\n",
+      "Writing :: ['2 0.24661458333333333 0.425 0.0234375 0.020370370370370372']\n",
+      "Writing :: ['2 0.4265625 0.4583333333333333 0.014583333333333334 0.027777777777777776']\n",
+      "Writing :: ['2 0.42942708333333335 0.36712962962962964 0.033854166666666664 0.026851851851851852']\n",
+      "Writing :: ['2 0.19947916666666668 0.34675925925925927 0.041666666666666664 0.03425925925925926']\n",
+      "Writing :: ['2 0.7953125 0.46064814814814814 0.030208333333333334 0.025']\n",
+      "Writing :: ['2 0.49635416666666665 0.3574074074074074 0.013541666666666667 0.024074074074074074']\n",
+      "Writing :: ['2 0.20703125 0.36666666666666664 0.028645833333333332 0.027777777777777776']\n",
+      "Writing :: ['2 0.5963541666666666 0.39861111111111114 0.0125 0.017592592592592594']\n",
+      "Writing :: ['2 0.36484375 0.3824074074074074 0.013020833333333334 0.016666666666666666']\n",
+      "Writing :: ['2 0.7453125 0.4546296296296296 0.029166666666666667 0.022222222222222223']\n",
+      "Writing :: ['2 0.9872395833333333 0.40925925925925927 0.024479166666666666 0.03333333333333333']\n",
+      "Writing :: ['2 0.44192708333333336 0.4527777777777778 0.018229166666666668 0.044444444444444446']\n",
+      "Writing :: ['2 0.3640625 0.29583333333333334 0.016666666666666666 0.026851851851851852']\n",
+      "Writing :: ['2 0.8966145833333333 0.5120370370370371 0.013020833333333334 0.03148148148148148']\n",
+      "Writing :: ['2 0.5328125 0.38425925925925924 0.013541666666666667 0.024074074074074074']\n",
+      "Writing :: ['2 0.6466145833333333 0.4486111111111111 0.03697916666666667 0.049074074074074076']\n",
+      "Writing :: ['2 0.2635416666666667 0.35462962962962963 0.04479166666666667 0.046296296296296294']\n",
+      "Writing :: ['2 0.77578125 0.46064814814814814 0.09114583333333333 0.07685185185185185']\n",
+      "Writing :: ['2 0.215625 0.4791666666666667 0.04791666666666667 0.0712962962962963']\n",
+      "Writing :: ['2 0.49296875 0.49675925925925923 0.15260416666666668 0.13425925925925927']\n",
+      "Writing :: ['2 0.26536458333333335 0.49398148148148147 0.04635416666666667 0.05462962962962963']\n",
+      "Writing :: ['2 0.6403645833333333 0.274537037037037 0.027604166666666666 0.025']\n",
+      "Writing :: ['2 0.5497395833333333 0.2912037037037037 0.0328125 0.023148148148148147']\n",
+      "Writing :: ['2 0.8526041666666667 0.4203703703703704 0.028125 0.05185185185185185']\n",
+      "Writing :: ['2 0.3377604166666667 0.34814814814814815 0.030729166666666665 0.024074074074074074']\n",
+      "Writing :: ['2 0.8416666666666667 0.5055555555555555 0.046875 0.027777777777777776']\n",
+      "Writing :: ['2 0.20989583333333334 0.6162037037037037 0.06770833333333333 0.03796296296296296']\n",
+      "Writing :: ['2 0.6869791666666667 0.38796296296296295 0.059375 0.05925925925925926']\n",
+      "Writing :: ['2 0.41432291666666665 0.38472222222222224 0.0390625 0.032407407407407406']\n",
+      "Writing :: ['2 0.4856770833333333 0.3199074074074074 0.018229166666666668 0.028703703703703703']\n",
+      "Writing :: ['2 0.3302083333333333 0.4148148148148148 0.023958333333333335 0.022222222222222223']\n",
+      "Writing :: ['2 0.06848958333333334 0.43703703703703706 0.05364583333333333 0.044444444444444446']\n",
+      "Writing :: ['2 0.8690104166666667 0.3768518518518518 0.05260416666666667 0.02962962962962963']\n",
+      "Writing :: ['2 0.765625 0.3365740740740741 0.017708333333333333 0.023148148148148147']\n",
+      "Writing :: ['2 0.4010416666666667 0.6449074074074074 0.17395833333333333 0.1527777777777778']\n",
+      "Writing :: ['2 0.61484375 0.37407407407407406 0.0234375 0.037037037037037035']\n",
+      "Writing :: ['2 0.13333333333333333 0.362962962962963 0.04479166666666667 0.05']\n",
+      "Writing :: ['2 0.36041666666666666 0.3106481481481482 0.011458333333333333 0.021296296296296296']\n",
+      "Writing :: ['2 0.4869791666666667 0.38055555555555554 0.0125 0.014814814814814815']\n",
+      "Writing :: ['2 0.3768229166666667 0.3990740740740741 0.0171875 0.027777777777777776']\n",
+      "Writing :: ['2 0.37005208333333334 0.3527777777777778 0.011979166666666667 0.014814814814814815']\n",
+      "Writing :: ['2 0.5408854166666667 0.4449074074074074 0.03802083333333333 0.030555555555555555']\n",
+      "Writing :: ['2 0.9466145833333334 0.4587962962962963 0.018229166666666668 0.017592592592592594']\n",
+      "Writing :: ['2 0.3645833333333333 0.4351851851851852 0.03125 0.024074074074074074']\n",
+      "Writing :: ['2 0.3307291666666667 0.31666666666666665 0.015625 0.020370370370370372']\n",
+      "Writing :: ['2 0.39427083333333335 0.4212962962962963 0.014583333333333334 0.024074074074074074']\n",
+      "Writing :: ['2 0.5984375 0.27037037037037037 0.011458333333333333 0.027777777777777776']\n",
+      "Writing :: ['2 0.6861979166666666 0.3476851851851852 0.0109375 0.013888888888888888']\n",
+      "Writing :: ['2 0.8703125 0.30972222222222223 0.01875 0.026851851851851852']\n",
+      "Writing :: ['2 0.4739583333333333 0.37546296296296294 0.013541666666666667 0.01574074074074074']\n",
+      "Writing :: ['2 0.39869791666666665 0.4398148148148148 0.0234375 0.020370370370370372']\n",
+      "Writing :: ['2 0.30442708333333335 0.38055555555555554 0.018229166666666668 0.022222222222222223']\n",
+      "Writing :: ['2 0.28203125 0.3347222222222222 0.013020833333333334 0.013888888888888888']\n",
+      "Writing :: ['2 0.8104166666666667 0.4787037037037037 0.03958333333333333 0.03888888888888889']\n",
+      "Writing :: ['2 0.41432291666666665 0.31712962962962965 0.009895833333333333 0.021296296296296296']\n",
+      "Writing :: ['2 0.4901041666666667 0.3486111111111111 0.011458333333333333 0.01574074074074074']\n",
+      "Writing :: ['2 0.47161458333333334 0.41388888888888886 0.050520833333333334 0.05']\n",
+      "Writing :: ['2 0.6643229166666667 0.4625 0.0328125 0.049074074074074076']\n",
+      "Writing :: ['2 0.7950520833333333 0.45925925925925926 0.08802083333333334 0.06851851851851852']\n",
+      "Writing :: ['1 0.23619791666666667 0.337037037037037 0.06197916666666667 0.044444444444444446']\n",
+      "Writing :: ['2 0.12760416666666666 0.3851851851851852 0.058333333333333334 0.046296296296296294']\n",
+      "Writing :: ['1 0.5434895833333333 0.2935185185185185 0.030729166666666665 0.024074074074074074']\n",
+      "Writing :: ['1 0.22526041666666666 0.45092592592592595 0.034895833333333334 0.05555555555555555']\n",
+      "Writing :: ['2 0.33984375 0.4148148148148148 0.024479166666666666 0.022222222222222223']\n",
+      "Writing :: ['0 0.49635416666666665 0.4930555555555556 0.15416666666666667 0.14537037037037037']\n",
+      "Writing :: ['2 0.48463541666666665 0.3175925925925926 0.022395833333333334 0.027777777777777776']\n",
+      "Writing :: ['1 0.8859375 0.38101851851851853 0.05520833333333333 0.030555555555555555']\n",
+      "Writing :: ['2 0.8640625 0.5078703703703704 0.052083333333333336 0.030555555555555555']\n",
+      "Writing :: ['2 0.6921875 0.387037037037037 0.052083333333333336 0.05740740740740741']\n",
+      "Writing :: ['2 0.35572916666666665 0.43796296296296294 0.029166666666666667 0.025925925925925925']\n",
+      "Writing :: ['2 0.6354166666666666 0.27361111111111114 0.03125 0.023148148148148147']\n",
+      "Writing :: ['2 0.40130208333333334 0.42314814814814816 0.0171875 0.020370370370370372']\n",
+      "Writing :: ['2 0.1109375 0.5856481481481481 0.06458333333333334 0.06018518518518518']\n",
+      "Writing :: ['2 0.3484375 0.3490740740740741 0.030208333333333334 0.024074074074074074']\n",
+      "Writing :: ['2 0.4393229166666667 0.3912037037037037 0.0265625 0.030555555555555555']\n",
+      "Writing :: ['2 0.2981770833333333 0.3851851851851852 0.022395833333333334 0.020370370370370372']\n",
+      "Writing :: ['0 0.39947916666666666 0.6453703703703704 0.16875 0.1537037037037037']\n",
+      "Writing :: ['2 0.55 0.44027777777777777 0.03958333333333333 0.026851851851851852']\n",
+      "Writing :: ['2 0.07083333333333333 0.45601851851851855 0.040625 0.05648148148148148']\n",
+      "Writing :: ['2 0.41458333333333336 0.3125 0.014583333333333334 0.025']\n",
+      "Writing :: ['2 0.32890625 0.32175925925925924 0.0109375 0.026851851851851852']\n",
+      "Writing :: ['2 0.6817708333333333 0.35185185185185186 0.011458333333333333 0.016666666666666666']\n",
+      "Writing :: ['2 0.6078125 0.38101851851851853 0.017708333333333333 0.028703703703703703']\n",
+      "Writing :: ['2 0.375 0.40185185185185185 0.0125 0.024074074074074074']\n",
+      "Writing :: ['2 0.36171875 0.30925925925925923 0.013020833333333334 0.022222222222222223']\n",
+      "Writing :: ['2 0.6786458333333333 0.4236111111111111 0.0125 0.019444444444444445']\n",
+      "Writing :: ['2 0.86015625 0.43657407407407406 0.0296875 0.05277777777777778']\n",
+      "Writing :: ['2 0.4236979166666667 0.4046296296296296 0.0171875 0.020370370370370372']\n",
+      "Writing :: ['2 0.8705729166666667 0.30416666666666664 0.018229166666666668 0.03425925925925926']\n",
+      "Writing :: ['2 0.81640625 0.48703703703703705 0.0328125 0.03888888888888889']\n",
+      "Writing :: ['2 0.47994791666666664 0.4111111111111111 0.04635416666666667 0.046296296296296294']\n",
+      "Writing :: ['2 0.045572916666666664 0.44814814814814813 0.030729166666666665 0.027777777777777776']\n",
+      "Writing :: ['2 0.5994791666666667 0.27824074074074073 0.009375 0.028703703703703703']\n",
+      "Writing :: ['2 0.42291666666666666 0.36944444444444446 0.014583333333333334 0.014814814814814815']\n",
+      "Writing :: ['2 0.9518229166666666 0.46574074074074073 0.016145833333333335 0.020370370370370372']\n",
+      "Writing :: ['2 0.33645833333333336 0.43472222222222223 0.0125 0.013888888888888888']\n",
+      "Writing :: ['2 0.9604166666666667 0.4837962962962963 0.03333333333333333 0.023148148148148147']\n",
+      "Writing :: ['2 0.1421875 0.500462962962963 0.0875 0.04537037037037037']\n",
+      "Writing :: ['2 0.41848958333333336 0.42962962962962964 0.0203125 0.022222222222222223']\n",
+      "Writing :: ['2 0.28072916666666664 0.33240740740740743 0.0125 0.014814814814814815']\n",
+      "Writing :: ['2 0.12083333333333333 0.35185185185185186 0.04583333333333333 0.03888888888888889']\n",
+      "Writing :: ['2 0.18697916666666667 0.387037037037037 0.022916666666666665 0.020370370370370372']\n",
+      "Writing :: ['2 0.3380208333333333 0.2912037037037037 0.04583333333333333 0.1361111111111111']\n",
+      "Writing :: ['2 0.5815104166666667 0.5148148148148148 0.09322916666666667 0.1037037037037037']\n",
+      "Writing :: ['2 0.51796875 0.5 0.07447916666666667 0.07962962962962963']\n",
+      "Writing :: ['2 0.42942708333333335 0.40925925925925927 0.03177083333333333 0.06111111111111111']\n",
+      "Writing :: ['2 0.39010416666666664 0.6564814814814814 0.16979166666666667 0.15925925925925927']\n",
+      "Writing :: ['2 0.5309895833333333 0.40879629629629627 0.0328125 0.04351851851851852']\n",
+      "Writing :: ['2 0.34765625 0.3300925925925926 0.05572916666666667 0.1287037037037037']\n",
+      "Writing :: ['2 0.36380208333333336 0.6810185185185185 0.2078125 0.16944444444444445']\n",
+      "Writing :: ['2 0.43385416666666665 0.2935185185185185 0.17395833333333333 0.17777777777777778']\n",
+      "Writing :: ['2 0.2981770833333333 0.3662037037037037 0.1328125 0.09722222222222222']\n",
+      "Writing :: ['2 0.39296875 0.4287037037037037 0.03802083333333333 0.037037037037037035']\n",
+      "Writing :: ['2 0.6140625 0.836574074074074 0.19583333333333333 0.19537037037037036']\n",
+      "Writing :: ['2 0.65625 0.36064814814814816 0.052083333333333336 0.058333333333333334']\n",
+      "Writing :: ['2 0.60078125 0.47453703703703703 0.0671875 0.08425925925925926']\n",
+      "Writing :: ['2 0.45234375 0.28888888888888886 0.17864583333333334 0.18703703703703703']\n",
+      "Writing :: ['2 0.33125 0.36157407407407405 0.13229166666666667 0.09351851851851851']\n",
+      "Writing :: ['2 0.6171875 0.46574074074074073 0.06145833333333333 0.08148148148148149']\n",
+      "Writing :: ['2 0.60859375 0.8314814814814815 0.2046875 0.19814814814814816']\n",
+      "Writing :: ['2 0.6486979166666667 0.3578703703703704 0.0484375 0.05462962962962963']\n",
+      "Writing :: ['2 0.38776041666666666 0.42916666666666664 0.03802083333333333 0.03981481481481482']\n",
+      "Writing :: ['2 0.45026041666666666 0.3476851851851852 0.12135416666666667 0.10092592592592593']\n",
+      "Writing :: ['2 0.5736979166666667 0.24722222222222223 0.2598958333333333 0.2222222222222222']\n",
+      "Writing :: ['2 0.6473958333333333 0.45555555555555555 0.05625 0.07222222222222222']\n",
+      "Writing :: ['2 0.60859375 0.8282407407407407 0.2078125 0.19907407407407407']\n",
+      "Writing :: ['2 0.36796875 0.43472222222222223 0.0296875 0.03796296296296296']\n",
+      "Writing :: ['2 0.5546875 0.32175925925925924 0.159375 0.14166666666666666']\n",
+      "Writing :: ['2 0.5203125 0.4217592592592593 0.06354166666666666 0.0824074074074074']\n",
+      "Writing :: ['2 0.56796875 0.8319444444444445 0.1453125 0.2490740740740741']\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_to_yolo(boxdf)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 0.4276041666666667 0.42453703703703705 0.05625 0.0712962962962963\r\n",
+      "2 0.2703125 0.5995370370370371 0.15104166666666666 0.12685185185185185\r\n",
+      "2 0.11640625 0.38935185185185184 0.033854166666666664 0.025\r\n",
+      "2 0.3502604166666667 0.36898148148148147 0.0140625 0.019444444444444445\r\n",
+      "2 0.43125 0.5606481481481481 0.1875 0.13425925925925927\r\n",
+      "2 0.15260416666666668 0.4583333333333333 0.028125 0.040740740740740744\r\n",
+      "2 0.7776041666666667 0.4708333333333333 0.027083333333333334 0.030555555555555555\r\n",
+      "2 0.40859375 0.42268518518518516 0.06927083333333334 0.0712962962962963\r\n",
+      "2 0.14583333333333334 0.38796296296296295 0.034375 0.024074074074074074\r\n",
+      "2 0.453125 0.5569444444444445 0.16770833333333332 0.12129629629629629\r\n",
+      "2 0.27838541666666666 0.6018518518518519 0.1484375 0.12777777777777777\r\n",
+      "2 0.33567708333333335 0.41898148148148145 0.0578125 0.06018518518518518\r\n",
+      "2 0.3151041666666667 0.6060185185185185 0.13229166666666667 0.1287037037037037\r\n",
+      "2 0.23463541666666668 0.3787037037037037 0.018229166666666668 0.024074074074074074\r\n",
+      "2 0.4765625 0.5569444444444445 0.11875 0.11018518518518519\r\n",
+      "2 0.33229166666666665 0.37777777777777777 0.023958333333333335 0.02962962962962963\r\n",
+      "2 0.3234375 0.34444444444444444 0.014583333333333334 0.025925925925925925\r\n",
+      "2 0.6213541666666667 0.41759259259259257 0.020833333333333332 0.018518518518518517\r\n",
+      "2 0.20338541666666668 0.5125 0.04010416666666667 0.026851851851851852\r\n",
+      "2 0.3302083333333333 0.6194444444444445 0.146875 0.12962962962962962\r\n",
+      "2 0.359375 0.3458333333333333 0.03229166666666667 0.030555555555555555\r\n",
+      "2 0.29583333333333334 0.4203703703703704 0.05520833333333333 0.05555555555555555\r\n",
+      "2 0.22916666666666666 0.3680555555555556 0.03229166666666667 0.026851851851851852\r\n",
+      "2 0.27578125 0.34444444444444444 0.019270833333333334 0.025925925925925925\r\n",
+      "2 0.6859375 0.47685185185185186 0.042708333333333334 0.025925925925925925\r\n",
+      "2 0.28020833333333334 0.42592592592592593 0.05416666666666667 0.05555555555555555\r\n",
+      "2 0.38203125 0.37037037037037035 0.0328125 0.03518518518518519\r\n",
+      "2 0.2109375 0.37453703703703706 0.0375 0.030555555555555555\r\n",
+      "2 0.27291666666666664 0.34814814814814815 0.01875 0.02962962962962963\r\n",
+      "2 0.34140625 0.6263888888888889 0.11822916666666666 0.11018518518518519\r\n",
+      "2 0.31875 0.38472222222222224 0.030208333333333334 0.028703703703703703\r\n",
+      "2 0.42916666666666664 0.4013888888888889 0.026041666666666668 0.026851851851851852\r\n",
+      "2 0.19791666666666666 0.38472222222222224 0.03125 0.026851851851851852\r\n",
+      "2 0.38333333333333336 0.6171296296296296 0.075 0.10648148148148148\r\n",
+      "2 0.27760416666666665 0.674537037037037 0.20104166666666667 0.15833333333333333\r\n",
+      "2 0.190625 0.38425925925925924 0.020833333333333332 0.024074074074074074\r\n",
+      "2 0.8395833333333333 0.4773148148148148 0.041666666666666664 0.026851851851851852\r\n",
+      "2 0.3609375 0.4185185185185185 0.014583333333333334 0.03518518518518519\r\n",
+      "2 0.5247395833333334 0.41759259259259257 0.034895833333333334 0.02962962962962963\r\n",
+      "2 0.11458333333333333 0.3699074074074074 0.03958333333333333 0.03425925925925926\r\n",
+      "2 0.365625 0.399537037037037 0.016666666666666666 0.03796296296296296\r\n",
+      "2 0.34479166666666666 0.3439814814814815 0.020833333333333332 0.019444444444444445\r\n",
+      "2 0.4354166666666667 0.4634259259259259 0.014583333333333334 0.017592592592592594\r\n",
+      "2 0.2953125 0.663425925925926 0.19583333333333333 0.1675925925925926\r\n",
+      "2 0.7104166666666667 0.4912037037037037 0.034375 0.023148148148148147\r\n",
+      "2 0.4122395833333333 0.39537037037037037 0.013020833333333334 0.022222222222222223\r\n",
+      "2 0.44427083333333334 0.600462962962963 0.109375 0.12685185185185185\r\n",
+      "2 0.29296875 0.3912037037037037 0.0140625 0.017592592592592594\r\n",
+      "2 0.496875 0.5212962962962963 0.04895833333333333 0.06481481481481481\r\n",
+      "2 0.8015625 0.36342592592592593 0.025 0.025\r\n",
+      "2 0.6036458333333333 0.4462962962962963 0.029166666666666667 0.06851851851851852\r\n",
+      "2 0.7604166666666666 0.4462962962962963 0.04375 0.027777777777777776\r\n",
+      "2 0.65546875 0.41759259259259257 0.0203125 0.046296296296296294\r\n",
+      "2 0.7729166666666667 0.40694444444444444 0.015625 0.026851851851851852\r\n",
+      "2 0.5239583333333333 0.5356481481481481 0.05520833333333333 0.11388888888888889\r\n",
+      "2 0.56953125 0.4615740740740741 0.07447916666666667 0.1712962962962963\r\n",
+      "2 0.4466145833333333 0.5907407407407408 0.0609375 0.09444444444444444\r\n",
+      "2 0.7794270833333333 0.43657407407407406 0.0265625 0.03611111111111111\r\n",
+      "2 0.80625 0.36203703703703705 0.019791666666666666 0.037037037037037035\r\n",
+      "2 0.55234375 0.36527777777777776 0.021354166666666667 0.03981481481481482\r\n",
+      "2 0.765625 0.39305555555555555 0.028125 0.03425925925925926\r\n",
+      "2 0.46822916666666664 0.5694444444444444 0.03854166666666667 0.11481481481481481\r\n",
+      "2 0.5255208333333333 0.5291666666666667 0.042708333333333334 0.09351851851851851\r\n",
+      "2 0.6419270833333334 0.3875 0.021354166666666667 0.030555555555555555\r\n",
+      "2 0.6109375 0.4564814814814815 0.028125 0.05185185185185185\r\n",
+      "2 0.48333333333333334 0.41898148148148145 0.01875 0.017592592592592594\r\n",
+      "2 0.48072916666666665 0.4388888888888889 0.021875 0.020370370370370372\r\n",
+      "2 0.5098958333333333 0.40185185185185185 0.016666666666666666 0.020370370370370372\r\n",
+      "2 0.5466145833333333 0.45231481481481484 0.0203125 0.028703703703703703\r\n",
+      "2 0.43203125 0.40370370370370373 0.0109375 0.012962962962962963\r\n",
+      "2 0.0578125 0.32731481481481484 0.01875 0.021296296296296296\r\n",
+      "2 0.40703125 0.3939814814814815 0.008854166666666666 0.017592592592592594\r\n",
+      "2 0.5419270833333333 0.3990740740740741 0.028645833333333332 0.027777777777777776\r\n",
+      "2 0.72421875 0.35 0.0515625 0.04259259259259259\r\n",
+      "2 0.6536458333333334 0.3365740740740741 0.03958333333333333 0.04351851851851852\r\n",
+      "2 0.38619791666666664 0.41759259259259257 0.04739583333333333 0.02962962962962963\r\n",
+      "2 0.809375 0.4101851851851852 0.041666666666666664 0.03148148148148148\r\n",
+      "2 0.6453125 0.46064814814814814 0.15104166666666666 0.13796296296296295\r\n",
+      "2 0.5546875 0.3425925925925926 0.03854166666666667 0.02962962962962963\r\n",
+      "2 0.4973958333333333 0.36018518518518516 0.027083333333333334 0.024074074074074074\r\n",
+      "2 0.4546875 0.375 0.04583333333333333 0.027777777777777776\r\n",
+      "2 0.4192708333333333 0.4601851851851852 0.034375 0.02962962962962963\r\n",
+      "2 0.5088541666666667 0.5356481481481481 0.11145833333333334 0.19907407407407407\r\n",
+      "2 0.5606770833333333 0.2953703703703704 0.0109375 0.03518518518518519\r\n",
+      "2 0.659375 0.3189814814814815 0.03229166666666667 0.025\r\n",
+      "2 0.6174479166666667 0.34444444444444444 0.0234375 0.024074074074074074\r\n",
+      "2 0.63046875 0.3402777777777778 0.03697916666666667 0.049074074074074076\r\n",
+      "2 0.3028645833333333 0.34814814814814815 0.0265625 0.024074074074074074\r\n",
+      "2 0.11015625 0.38055555555555554 0.1328125 0.10555555555555556\r\n",
+      "2 0.6984375 0.3902777777777778 0.053125 0.049074074074074076\r\n",
+      "2 0.4505208333333333 0.2388888888888889 0.03333333333333333 0.03333333333333333\r\n",
+      "2 0.4234375 0.30462962962962964 0.051041666666666666 0.053703703703703705\r\n",
+      "2 0.4002604166666667 0.37222222222222223 0.0328125 0.03518518518518519\r\n",
+      "2 0.33567708333333335 0.37222222222222223 0.024479166666666666 0.018518518518518517\r\n",
+      "2 0.40729166666666666 0.41944444444444445 0.04583333333333333 0.046296296296296294\r\n",
+      "2 0.5372395833333333 0.44907407407407407 0.03177083333333333 0.03333333333333333\r\n",
+      "2 0.378125 0.3199074074074074 0.041666666666666664 0.04351851851851852\r\n",
+      "2 0.6028645833333334 0.4537037037037037 0.021354166666666667 0.020370370370370372\r\n",
+      "2 0.7533854166666667 0.49074074074074076 0.0359375 0.025925925925925925\r\n",
+      "2 0.3848958333333333 0.43333333333333335 0.0125 0.04814814814814815\r\n",
+      "2 0.43411458333333336 0.3425925925925926 0.028645833333333332 0.025925925925925925\r\n",
+      "2 0.6341145833333334 0.4217592592592593 0.04010416666666667 0.03981481481481482\r\n",
+      "2 0.34348958333333335 0.6337962962962963 0.16302083333333334 0.16944444444444445\r\n",
+      "2 0.7018229166666666 0.5060185185185185 0.027604166666666666 0.025\r\n",
+      "2 0.7106770833333333 0.4527777777777778 0.013020833333333334 0.03333333333333333\r\n",
+      "2 0.3419270833333333 0.46620370370370373 0.027604166666666666 0.05277777777777778\r\n",
+      "2 0.35885416666666664 0.4356481481481482 0.022916666666666665 0.021296296296296296\r\n",
+      "2 0.24661458333333333 0.425 0.0234375 0.020370370370370372\r\n",
+      "2 0.4265625 0.4583333333333333 0.014583333333333334 0.027777777777777776\r\n",
+      "2 0.42942708333333335 0.36712962962962964 0.033854166666666664 0.026851851851851852\r\n",
+      "2 0.19947916666666668 0.34675925925925927 0.041666666666666664 0.03425925925925926\r\n",
+      "2 0.7953125 0.46064814814814814 0.030208333333333334 0.025\r\n",
+      "2 0.49635416666666665 0.3574074074074074 0.013541666666666667 0.024074074074074074\r\n",
+      "2 0.20703125 0.36666666666666664 0.028645833333333332 0.027777777777777776\r\n",
+      "2 0.5963541666666666 0.39861111111111114 0.0125 0.017592592592592594\r\n",
+      "2 0.36484375 0.3824074074074074 0.013020833333333334 0.016666666666666666\r\n",
+      "2 0.7453125 0.4546296296296296 0.029166666666666667 0.022222222222222223\r\n",
+      "2 0.9872395833333333 0.40925925925925927 0.024479166666666666 0.03333333333333333\r\n",
+      "2 0.44192708333333336 0.4527777777777778 0.018229166666666668 0.044444444444444446\r\n",
+      "2 0.3640625 0.29583333333333334 0.016666666666666666 0.026851851851851852\r\n",
+      "2 0.8966145833333333 0.5120370370370371 0.013020833333333334 0.03148148148148148\r\n",
+      "2 0.5328125 0.38425925925925924 0.013541666666666667 0.024074074074074074\r\n",
+      "2 0.6466145833333333 0.4486111111111111 0.03697916666666667 0.049074074074074076\r\n",
+      "2 0.2635416666666667 0.35462962962962963 0.04479166666666667 0.046296296296296294\r\n",
+      "2 0.77578125 0.46064814814814814 0.09114583333333333 0.07685185185185185\r\n",
+      "2 0.215625 0.4791666666666667 0.04791666666666667 0.0712962962962963\r\n",
+      "2 0.49296875 0.49675925925925923 0.15260416666666668 0.13425925925925927\r\n",
+      "2 0.26536458333333335 0.49398148148148147 0.04635416666666667 0.05462962962962963\r\n",
+      "2 0.6403645833333333 0.274537037037037 0.027604166666666666 0.025\r\n",
+      "2 0.5497395833333333 0.2912037037037037 0.0328125 0.023148148148148147\r\n",
+      "2 0.8526041666666667 0.4203703703703704 0.028125 0.05185185185185185\r\n",
+      "2 0.3377604166666667 0.34814814814814815 0.030729166666666665 0.024074074074074074\r\n",
+      "2 0.8416666666666667 0.5055555555555555 0.046875 0.027777777777777776\r\n",
+      "2 0.20989583333333334 0.6162037037037037 0.06770833333333333 0.03796296296296296\r\n",
+      "2 0.6869791666666667 0.38796296296296295 0.059375 0.05925925925925926\r\n",
+      "2 0.41432291666666665 0.38472222222222224 0.0390625 0.032407407407407406\r\n",
+      "2 0.4856770833333333 0.3199074074074074 0.018229166666666668 0.028703703703703703\r\n",
+      "2 0.3302083333333333 0.4148148148148148 0.023958333333333335 0.022222222222222223\r\n",
+      "2 0.06848958333333334 0.43703703703703706 0.05364583333333333 0.044444444444444446\r\n",
+      "2 0.8690104166666667 0.3768518518518518 0.05260416666666667 0.02962962962962963\r\n",
+      "2 0.765625 0.3365740740740741 0.017708333333333333 0.023148148148148147\r\n",
+      "2 0.4010416666666667 0.6449074074074074 0.17395833333333333 0.1527777777777778\r\n",
+      "2 0.61484375 0.37407407407407406 0.0234375 0.037037037037037035\r\n",
+      "2 0.13333333333333333 0.362962962962963 0.04479166666666667 0.05\r\n",
+      "2 0.36041666666666666 0.3106481481481482 0.011458333333333333 0.021296296296296296\r\n",
+      "2 0.4869791666666667 0.38055555555555554 0.0125 0.014814814814814815\r\n",
+      "2 0.3768229166666667 0.3990740740740741 0.0171875 0.027777777777777776\r\n",
+      "2 0.37005208333333334 0.3527777777777778 0.011979166666666667 0.014814814814814815\r\n",
+      "2 0.5408854166666667 0.4449074074074074 0.03802083333333333 0.030555555555555555\r\n",
+      "2 0.9466145833333334 0.4587962962962963 0.018229166666666668 0.017592592592592594\r\n",
+      "2 0.3645833333333333 0.4351851851851852 0.03125 0.024074074074074074\r\n",
+      "2 0.3307291666666667 0.31666666666666665 0.015625 0.020370370370370372\r\n",
+      "2 0.39427083333333335 0.4212962962962963 0.014583333333333334 0.024074074074074074\r\n",
+      "2 0.5984375 0.27037037037037037 0.011458333333333333 0.027777777777777776\r\n",
+      "2 0.6861979166666666 0.3476851851851852 0.0109375 0.013888888888888888\r\n",
+      "2 0.8703125 0.30972222222222223 0.01875 0.026851851851851852\r\n",
+      "2 0.4739583333333333 0.37546296296296294 0.013541666666666667 0.01574074074074074\r\n",
+      "2 0.39869791666666665 0.4398148148148148 0.0234375 0.020370370370370372\r\n",
+      "2 0.30442708333333335 0.38055555555555554 0.018229166666666668 0.022222222222222223\r\n",
+      "2 0.28203125 0.3347222222222222 0.013020833333333334 0.013888888888888888\r\n",
+      "2 0.8104166666666667 0.4787037037037037 0.03958333333333333 0.03888888888888889\r\n",
+      "2 0.41432291666666665 0.31712962962962965 0.009895833333333333 0.021296296296296296\r\n",
+      "2 0.4901041666666667 0.3486111111111111 0.011458333333333333 0.01574074074074074\r\n",
+      "2 0.47161458333333334 0.41388888888888886 0.050520833333333334 0.05\r\n",
+      "2 0.6643229166666667 0.4625 0.0328125 0.049074074074074076\r\n",
+      "2 0.7950520833333333 0.45925925925925926 0.08802083333333334 0.06851851851851852\r\n",
+      "1 0.23619791666666667 0.337037037037037 0.06197916666666667 0.044444444444444446\r\n",
+      "2 0.12760416666666666 0.3851851851851852 0.058333333333333334 0.046296296296296294\r\n",
+      "1 0.5434895833333333 0.2935185185185185 0.030729166666666665 0.024074074074074074\r\n",
+      "1 0.22526041666666666 0.45092592592592595 0.034895833333333334 0.05555555555555555\r\n",
+      "2 0.33984375 0.4148148148148148 0.024479166666666666 0.022222222222222223\r\n",
+      "0 0.49635416666666665 0.4930555555555556 0.15416666666666667 0.14537037037037037\r\n",
+      "2 0.48463541666666665 0.3175925925925926 0.022395833333333334 0.027777777777777776\r\n",
+      "1 0.8859375 0.38101851851851853 0.05520833333333333 0.030555555555555555\r\n",
+      "2 0.8640625 0.5078703703703704 0.052083333333333336 0.030555555555555555\r\n",
+      "2 0.6921875 0.387037037037037 0.052083333333333336 0.05740740740740741\r\n",
+      "2 0.35572916666666665 0.43796296296296294 0.029166666666666667 0.025925925925925925\r\n",
+      "2 0.6354166666666666 0.27361111111111114 0.03125 0.023148148148148147\r\n",
+      "2 0.40130208333333334 0.42314814814814816 0.0171875 0.020370370370370372\r\n",
+      "2 0.1109375 0.5856481481481481 0.06458333333333334 0.06018518518518518\r\n",
+      "2 0.3484375 0.3490740740740741 0.030208333333333334 0.024074074074074074\r\n",
+      "2 0.4393229166666667 0.3912037037037037 0.0265625 0.030555555555555555\r\n",
+      "2 0.2981770833333333 0.3851851851851852 0.022395833333333334 0.020370370370370372\r\n",
+      "0 0.39947916666666666 0.6453703703703704 0.16875 0.1537037037037037\r\n",
+      "2 0.55 0.44027777777777777 0.03958333333333333 0.026851851851851852\r\n",
+      "2 0.07083333333333333 0.45601851851851855 0.040625 0.05648148148148148\r\n",
+      "2 0.41458333333333336 0.3125 0.014583333333333334 0.025\r\n",
+      "2 0.32890625 0.32175925925925924 0.0109375 0.026851851851851852\r\n",
+      "2 0.6817708333333333 0.35185185185185186 0.011458333333333333 0.016666666666666666\r\n",
+      "2 0.6078125 0.38101851851851853 0.017708333333333333 0.028703703703703703\r\n",
+      "2 0.375 0.40185185185185185 0.0125 0.024074074074074074\r\n",
+      "2 0.36171875 0.30925925925925923 0.013020833333333334 0.022222222222222223\r\n",
+      "2 0.6786458333333333 0.4236111111111111 0.0125 0.019444444444444445\r\n",
+      "2 0.86015625 0.43657407407407406 0.0296875 0.05277777777777778\r\n",
+      "2 0.4236979166666667 0.4046296296296296 0.0171875 0.020370370370370372\r\n",
+      "2 0.8705729166666667 0.30416666666666664 0.018229166666666668 0.03425925925925926\r\n",
+      "2 0.81640625 0.48703703703703705 0.0328125 0.03888888888888889\r\n",
+      "2 0.47994791666666664 0.4111111111111111 0.04635416666666667 0.046296296296296294\r\n",
+      "2 0.045572916666666664 0.44814814814814813 0.030729166666666665 0.027777777777777776\r\n",
+      "2 0.5994791666666667 0.27824074074074073 0.009375 0.028703703703703703\r\n",
+      "2 0.42291666666666666 0.36944444444444446 0.014583333333333334 0.014814814814814815\r\n",
+      "2 0.9518229166666666 0.46574074074074073 0.016145833333333335 0.020370370370370372\r\n",
+      "2 0.33645833333333336 0.43472222222222223 0.0125 0.013888888888888888\r\n",
+      "2 0.9604166666666667 0.4837962962962963 0.03333333333333333 0.023148148148148147\r\n",
+      "2 0.1421875 0.500462962962963 0.0875 0.04537037037037037\r\n",
+      "2 0.41848958333333336 0.42962962962962964 0.0203125 0.022222222222222223\r\n",
+      "2 0.28072916666666664 0.33240740740740743 0.0125 0.014814814814814815\r\n",
+      "2 0.12083333333333333 0.35185185185185186 0.04583333333333333 0.03888888888888889\r\n",
+      "2 0.18697916666666667 0.387037037037037 0.022916666666666665 0.020370370370370372\r\n",
+      "2 0.3380208333333333 0.2912037037037037 0.04583333333333333 0.1361111111111111\r\n",
+      "2 0.5815104166666667 0.5148148148148148 0.09322916666666667 0.1037037037037037\r\n",
+      "2 0.51796875 0.5 0.07447916666666667 0.07962962962962963\r\n",
+      "2 0.42942708333333335 0.40925925925925927 0.03177083333333333 0.06111111111111111\r\n",
+      "2 0.39010416666666664 0.6564814814814814 0.16979166666666667 0.15925925925925927\r\n",
+      "2 0.5309895833333333 0.40879629629629627 0.0328125 0.04351851851851852\r\n",
+      "2 0.34765625 0.3300925925925926 0.05572916666666667 0.1287037037037037\r\n",
+      "2 0.36380208333333336 0.6810185185185185 0.2078125 0.16944444444444445\r\n",
+      "2 0.43385416666666665 0.2935185185185185 0.17395833333333333 0.17777777777777778\r\n",
+      "2 0.2981770833333333 0.3662037037037037 0.1328125 0.09722222222222222\r\n",
+      "2 0.39296875 0.4287037037037037 0.03802083333333333 0.037037037037037035\r\n",
+      "2 0.6140625 0.836574074074074 0.19583333333333333 0.19537037037037036\r\n",
+      "2 0.65625 0.36064814814814816 0.052083333333333336 0.058333333333333334\r\n",
+      "2 0.60078125 0.47453703703703703 0.0671875 0.08425925925925926\r\n",
+      "2 0.45234375 0.28888888888888886 0.17864583333333334 0.18703703703703703\r\n",
+      "2 0.33125 0.36157407407407405 0.13229166666666667 0.09351851851851851\r\n",
+      "2 0.6171875 0.46574074074074073 0.06145833333333333 0.08148148148148149\r\n",
+      "2 0.60859375 0.8314814814814815 0.2046875 0.19814814814814816\r\n",
+      "2 0.6486979166666667 0.3578703703703704 0.0484375 0.05462962962962963\r\n",
+      "2 0.38776041666666666 0.42916666666666664 0.03802083333333333 0.03981481481481482\r\n",
+      "2 0.45026041666666666 0.3476851851851852 0.12135416666666667 0.10092592592592593\r\n",
+      "2 0.5736979166666667 0.24722222222222223 0.2598958333333333 0.2222222222222222\r\n",
+      "2 0.6473958333333333 0.45555555555555555 0.05625 0.07222222222222222\r\n",
+      "2 0.60859375 0.8282407407407407 0.2078125 0.19907407407407407\r\n",
+      "2 0.36796875 0.43472222222222223 0.0296875 0.03796296296296296\r\n",
+      "2 0.5546875 0.32175925925925924 0.159375 0.14166666666666666\r\n",
+      "2 0.5203125 0.4217592592592593 0.06354166666666666 0.0824074074074074\r\n",
+      "2 0.56796875 0.8319444444444445 0.1453125 0.2490740740740741\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!cat train/em_yolo.txt"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "outputs": [],
+   "source": [
+    "def extract_frames_from_video(video, frame_number):\n",
+    "    \"\"\"\n",
+    "    Given a BRUVS video, extract the frame as a jpg.\n",
+    "    :param video:\n",
+    "    :param frame_number:\n",
+    "    :return:\n",
+    "    \"\"\"\n",
+    "    vid = cv2.VideoCapture(video)\n",
+    "    vid.set(1, frame_number - 1)\n",
+    "\n",
+    "    ret, image = vid.read()\n",
+    "    return image"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "outputs": [],
+   "source": [
+    "img = extract_frames_from_video(os.path.join(TEST_FILES_PATH,boxdf['str_filename'].iloc[0].decode('utf-8')), boxdf['n_frame'].iloc[0])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "True"
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cv2.imwrite('test.png', img)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "<img src='test.png'>\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "(237, 20)"
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "boxdf.shape"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<IntegerArray>\n[ 6957,  6965,  6992,  7012,  7020,  7035,  7338,  7365,  7571,  7577,  7628,\n 10796, 10913, 10916, 11623, 14521, 17780, 17786, 17807, 17981]\nLength: 20, dtype: Int64"
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "boxdf['n_frame'].unique()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6957\n",
+      "0\n",
+      "6965\n",
+      "7\n",
+      "6992\n",
+      "11\n",
+      "7012\n",
+      "19\n",
+      "7020\n",
+      "25\n",
+      "7035\n",
+      "30\n",
+      "7338\n",
+      "34\n",
+      "7365\n",
+      "38\n",
+      "7571\n",
+      "49\n",
+      "7577\n",
+      "57\n",
+      "7628\n",
+      "73\n",
+      "10796\n",
+      "86\n",
+      "10913\n",
+      "122\n",
+      "10916\n",
+      "164\n",
+      "11623\n",
+      "209\n",
+      "14521\n",
+      "215\n",
+      "17780\n",
+      "217\n",
+      "17786\n",
+      "223\n",
+      "17807\n",
+      "229\n",
+      "17981\n",
+      "234\n"
+     ]
+    }
+   ],
+   "source": [
+    "for ii, frame in enumerate(boxdf['n_frame'].unique()):\n",
+    "    print(frame)\n",
+    "    ii_loc = pd.Index(boxdf['n_frame']).get_loc(frame).start # slice object\n",
+    "    print(ii_loc)\n",
+    "    img = extract_frames_from_video(os.path.join(TEST_FILES_PATH, boxdf['str_filename'].iloc[ii_loc].decode('utf-8')), boxdf['n_frame'].iloc[ii_loc])\n",
+    "    cv2.imwrite(f'train/{frame}_test.png', img)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
    "metadata": {
     "collapsed": false,
     "pycharm": {

--- a/src/notebooks/gen_yolo_training_data.ipynb
+++ b/src/notebooks/gen_yolo_training_data.ipynb
@@ -18,11 +18,7 @@
    "outputs": [],
    "source": [
     "import os, sys\n",
-    "from typing import Any\n",
     "import cv2\n",
-    "\n",
-    "from pandas import Series, DataFrame\n",
-    "from pandas.core.generic import NDFrame\n",
     "\n",
     "sys.path.append(\"..\")\n",
     "\n",
@@ -74,21 +70,6 @@
    "source": [
     "TEST_FILES_PATH = '/home/marrabld/data/test_emobs/emtmlibpy'\n",
     "TEST_FILE = 'afid.EMObs'"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 67,
-   "outputs": [],
-   "source": [
-    "# TEST_FILES_PATH = '/home/marrabld/data/test_emobs/RB95'\n",
-    "# TEST_FILE = '20_ RB95.EMObs_AUTO'"
    ],
    "metadata": {
     "collapsed": false,

--- a/src/scripts/gen_yolo_training_data.py
+++ b/src/scripts/gen_yolo_training_data.py
@@ -1,0 +1,30 @@
+import os, sys
+from typing import Any
+import cv2
+
+from pandas import Series, DataFrame
+from pandas.core.generic import NDFrame
+
+sys.path.append("..")
+
+import emtmlibpy.emtmlibpy as emtm
+from emtmlibpy.emtmlibpy import EMTMResult
+
+import numpy as np
+import pandas as pd
+from argparse import ArgumentParser
+
+def main():
+    """
+    Main entry point
+    :return:
+    """
+    print('main')
+
+if __name__ == '__main__':
+    parser = ArgumentParser('emobs')
+    parser.add_argument('emobs_path', help='Path to the EMObs annotation file')
+    parser.add_argument('-v', required=True, help='Path to the video to extract frames')
+    
+    args = parser.parse_args()
+    exit(main(args) or 0)

--- a/src/scripts/gen_yolo_training_data.py
+++ b/src/scripts/gen_yolo_training_data.py
@@ -1,30 +1,173 @@
-import os, sys
-from typing import Any
-import cv2
+import os
+import sys
+from collections import namedtuple
+from pathlib import Path
 
-from pandas import Series, DataFrame
-from pandas.core.generic import NDFrame
+import cv2
 
 sys.path.append("..")
 
 import emtmlibpy.emtmlibpy as emtm
-from emtmlibpy.emtmlibpy import EMTMResult
 
 import numpy as np
 import pandas as pd
 from argparse import ArgumentParser
 
-def main():
+
+def point_to_df():
+    """
+    Convert EvemtMeasure points to a dataframe
+    :return: Pandas dataframe
+    """
+    dtype_template = 'object'
+    point_count, box_count = emtm.em_point_count()
+    print(f'number of points :: {point_count}')
+    print(f'number of boxes :: {box_count}')
+
+    p = emtm.em_get_point(0)
+    index = [attr for attr in dir(p) if (not attr.startswith('__') and not attr.startswith('_'))]
+    data = np.empty(shape=[point_count, len(index)], dtype=dtype_template)  # change these
+
+    for jj in range(point_count):
+        p = emtm.em_get_point(jj)
+        for ii, ind in enumerate(index):
+            tmp = p.__getattribute__(ind)
+            data[jj][ii] = tmp
+
+    xpdf = pd.DataFrame(data=data, columns=index)
+    xpdf = xpdf.convert_dtypes().infer_objects()
+    return xpdf
+
+
+def em_box_coords_to_yolo(x: float, y: float, box_width: float, box_height: float, image_width: float = 1920,
+                          image_height: float = 1080) -> namedtuple:
+    """
+    Helper function to transform the EventMeasure coord to yolo coords.
+    YOLO coordinates are x, y, centre of the box and all coords normalised by image width and height
+    :param image_height:
+    :param image_width:
+    :param box_height:
+    :param box_width:
+    :param x: Pixel column
+    :param y: Pixel row
+    :return: namedtuple (x, y, width, height)
+    """
+
+    XYWH = namedtuple('XYHW', 'x y width height')
+
+    yolo_x = (x + box_width / 2) / image_width
+    yolo_y = (y + box_height / 2) / image_height
+    yolo_box_width = box_width / image_width
+    yolo_box_height = box_height / image_height
+
+    return XYWH(yolo_x, yolo_y, yolo_box_width, yolo_box_height)
+
+
+def df_to_yolo(df: pd.DataFrame, out_dir='train', image_width=1920, image_height=1080):
+    """
+    Given a data frame write out a directory with training data in the YOLO format
+    <object-class> <x> <y> <width> <height>
+
+    integer number of object from 0 to (classes-1) - float values relative to width and height of image, it can be equal from (0.0 to 1.0] for example: <x> = <absolute_x> / <image_width> or <height> = <absolute_height> / <image_height> atention: <x> <y> - are center of rectangle (are not top-left corner)
+    :param df:
+    :return:
+    """
+    os.makedirs(out_dir, exist_ok=True)
+
+    label = []
+    for index, row in df.iterrows():
+        # concatinate fgs for the label name
+        label.append(
+            f"{row['str_family'].decode('utf-8')}_{row['str_genus'].decode('utf-8')}_{row['str_species'].decode('utf-8')}")
+    label = list(set(label))
+    print(f'Unique Labels :: {label}')
+
+    # Now we have the unique labels pull them out and create the string format.
+
+    for index, row in df.iterrows():
+        with open(os.path.join(out_dir,
+                               f"{df['str_filename'].iloc[index].decode('utf-8')}_{df['n_frame'].iloc[index]}.txt"),
+                  'ab') as f:
+            row_label = []
+            row_string = []
+            r = em_box_coords_to_yolo(row['d_imx'], row['d_imy'], row['d_rectx'], row['d_recty'])
+            # concatinate fgs for the label name
+            row_label = f"{row['str_family'].decode('utf-8')}_{row['str_genus'].decode('utf-8')}_{row['str_species'].decode('utf-8')}"
+            label_num = label.index(row_label)
+            # Add the coordinates and boxes
+            row_string.append(f"{label_num} {r.x} {r.y} {r.width} {r.height}")
+
+            print(f'Writing :: {row_string}')
+            f.write(f'{row_string[0]}\n'.encode())
+
+    Path(args.output_directory).mkdir(parents=True, exist_ok=True)
+    class_file = os.path.join(args.output_directory, 'classes.txt')
+
+    with open(class_file, 'w') as f:
+        for _class in label:
+            f.write(f"{_class}\n")
+
+
+def extract_frames_from_video(video, frame_number):
+    """
+    Given a BRUVS video, extract the frame as a jpg.
+    :param video: The BRUVS video
+    :param frame_number: The frame to extract from the video
+    :return:
+    """
+    vid = cv2.VideoCapture(video)
+    vid.set(1, frame_number)
+
+    ret, image = vid.read()
+    return image
+
+
+def main(args):
     """
     Main entry point
     :return:
     """
     print('main')
 
+    print(f'Using Version {emtm.emtm_version()} of emtmlib')
+
+    r = emtm.em_load_data(args.emobs_path)
+    n_fgs = emtm.em_unique_fgs()
+    fgs = []
+
+    for ii in range(n_fgs):
+        fgs.append(emtm.em_get_unique_fgs(ii))
+
+    print(f"Unique FGS :: {fgs}")
+
+
+
+    pdf = point_to_df()
+    boxdf = pdf[pdf['d_rectx'] >= 0]
+
+    df_to_yolo(boxdf, out_dir=args.output_directory)
+
+    # there might be many annotations per frame.  We just want the unique ones.
+    boxdf['n_frame'].unique()
+
+    for ii, frame in enumerate(boxdf['n_frame'].unique()):
+        print(f'Extracting frame :: {frame} ')
+        ii_loc = pd.Index(boxdf['n_frame']).get_loc(frame).start  # slice object
+
+        img = extract_frames_from_video(
+            os.path.join(os.path.dirname(args.emobs_path), boxdf['str_filename'].iloc[ii_loc].decode('utf-8')),
+            boxdf['n_frame'].iloc[ii_loc])
+        cv2.imwrite(f"{args.output_directory}/{boxdf['str_filename'].iloc[ii_loc].decode('utf-8')}_{boxdf['n_frame'].iloc[ii_loc]}.png",
+                    img)
+
+
 if __name__ == '__main__':
     parser = ArgumentParser('emobs')
-    parser.add_argument('emobs_path', help='Path to the EMObs annotation file')
-    parser.add_argument('-v', required=True, help='Path to the video to extract frames')
-    
+    parser.add_argument('emobs_path',
+                        help='Path to the EMObs annotation file. The EMObs file needs to be in the same directory as the videos')
+    # parser.add_argument('-v', '--video-path', required=True, help='Path to the video to extract frames')
+    parser.add_argument('-o', '--output-directory', required=True,
+                        help='The output path to place the images and training files.')
+
     args = parser.parse_args()
     exit(main(args) or 0)


### PR DESCRIPTION
The main useful addon here is the command line script we can use to extract frames for training in the yolo format given and EMObs file and BRUVS video.  

The notebook is more an explanation. The script [gen_yolo_training_data.py](https://github.com/AutomatedFishID/emtmlibpy/blob/yolo_notebook/src/scripts/gen_yolo_training_data.py)  is the thing we can use to bulk extract training images. 