### PR TITLE
Export functions from __init__

### DIFF
--- a/src/emtmlibpy/__init__.py
+++ b/src/emtmlibpy/__init__.py
@@ -1,0 +1,1 @@
+from .emtmlibpy import *


### PR DESCRIPTION
This allows "import emtmlibpy" as opposed to "from emtmlibpy import emtmlibpy"

```In [15]: import emtmlibpy

In [16]: emtmlibpy.emtm_version()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In [16], line 1
----> 1 emtmlibpy.emtm_version()

AttributeError: module 'emtmlibpy' has no attribute 'emtm_version'

In [17]: from emtmlibpy import emtmlibpy

In [18]: emtmlibpy.emtm_version()
Out[18]: (2, 0)
```