### PR TITLE
Add requirements to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,9 @@ package_dir =
     = src
 packages = find:
 python_requires = >=3.6
+install_requires =
+    pandas>= 1.5.0,< 1.6.9
+    numpy>=1.22.3
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This is to make sure that pip installing this library also installs `pandas` and `numpy`. The version for numpy is lowered to allow for compatibility with `afid-detectors`, which is pinned to version 1.22.3 (not sure why). 