### PR TITLE
Decode strings instead of returning byte strings

### DIFF
--- a/src/emtmlibpy/emtmlibpy.py
+++ b/src/emtmlibpy/emtmlibpy.py
@@ -399,7 +399,7 @@ def em_op_code(n_buff_sz: int = EMTM_MAX_CHARS) -> str:
 
     libc.EMOpCode(ctypes.byref(op_code), n_buff_sz)
 
-    return op_code.value
+    return op_code.value.decode()
 
 
 def em_units(n_buff_sz: int = EMTM_MAX_CHARS) -> str:
@@ -419,7 +419,7 @@ def em_units(n_buff_sz: int = EMTM_MAX_CHARS) -> str:
 
     libc.EMUnits(ctypes.byref(p_str_units))
 
-    return p_str_units.value
+    return p_str_units.value.decode()
 
 
 def em_unique_fgs() -> int:
@@ -485,7 +485,7 @@ def em_get_unique_fgs(n_index: int) -> tuple:
                                   ctypes.byref(p_str_family), ctypes.byref(p_str_genus), ctypes.byref(p_str_species),
                                   EMTM_MAX_CHARS)
 
-    return p_str_family.value, p_str_genus.value, p_str_species.value
+    return p_str_family.value.decode(), p_str_genus.value.decode(), p_str_species.value.decode()
 
 
 def em_measurement_count_fgs(family: str, genus: str, species: str) -> tuple:

--- a/src/test_emtmlibpy.py
+++ b/src/test_emtmlibpy.py
@@ -33,11 +33,11 @@ class TestEmtmlibpy(unittest.TestCase):
         self.assertIs(EMTMResult(r), EMTMResult(0))
 
         r = emtm.em_op_code()
-        self.assertEqual(r, b'Test')
+        self.assertEqual(r, 'Test')
 
     def test_em_units(self):
         r = emtm.em_units()
-        self.assertEqual(r, b'mm')
+        self.assertEqual(r, 'mm')
 
     def test_em_unique_fgs(self):
         r = emtm.em_unique_fgs()
@@ -46,12 +46,12 @@ class TestEmtmlibpy(unittest.TestCase):
     def test_get_unique_fgs(self):
         r = emtm.em_load_data(os.path.join(TEST_FILES_PATH, 'Test.EMObs'))
 
-        fgs = [(b'', b'', b''),
-               (b'balistidae', b'abalistes', b'stellatus'),
-               (b'nemipteridae', b'nemipterus', b'furcosus'),
-               (b'nemipteridae', b'pentapodus', b'porosus'),
-               (b'pinguipedidae', b'parapercis', b'xanthozona'),
-               (b'scombridae', b'scomberomorus', b'queenslandicus')]
+        fgs = [('', '', ''),
+               ('balistidae', 'abalistes', 'stellatus'),
+               ('nemipteridae', 'nemipterus', 'furcosus'),
+               ('nemipteridae', 'pentapodus', 'porosus'),
+               ('pinguipedidae', 'parapercis', 'xanthozona'),
+               ('scombridae', 'scomberomorus', 'queenslandicus')]
 
         n_unique = emtm.em_unique_fgs()
 


### PR DESCRIPTION
Most of the time users of the library will want the decoded strings rather than the bytes. I think it's nicer to do this in the library instead of needing to call `.decode()` every time you call one of these functions. 

Confirmed that the tests pass :tada: 