### PR TITLE
Match the return type of the EM/TM load_data functions to the type hint

### DIFF
--- a/src/emtmlibpy/emtmlibpy.py
+++ b/src/emtmlibpy/emtmlibpy.py
@@ -366,7 +366,7 @@ def em_load_data(filename: str) -> EMTMResult:
     :param filename:
     :return: EMTMResult
     """
-    return libc.EMLoadData(bytes(filename, 'UTF-8'))
+    return EMTMResult(libc.EMLoadData(bytes(filename, 'UTF-8')))
 
 
 def em_clear_data() -> None:
@@ -728,7 +728,7 @@ def tm_load_data(filename: str) -> EMTMResult:
     """
 
     r = libc.TMLoadData(bytes(filename, 'UTF-8'))
-    return r
+    return EMTMResult(r)
 
 
 def tm_clear_data() -> None:


### PR DESCRIPTION
Small fixes for consistency with the type hints used.

I have a slightly bigger follow-up PR based on this one but decided to separate this innocuous fix, in case the bigger one doesn't fit with your plans :) . Happy to merge them in sequence, just go with the bigger one or disentangle them completely, as preferred.