### PR TITLE
Generalise Pandas helper

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     pandas>= 1.5.0,< 1.6.9
     numpy>=1.22.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.9
 install_requires =
     pandas>= 1.5.0,< 1.6.9
     numpy>=1.22.3

--- a/src/emtmlibpy/emtmlibpy.py
+++ b/src/emtmlibpy/emtmlibpy.py
@@ -366,7 +366,7 @@ def em_load_data(filename: str) -> EMTMResult:
     :param filename:
     :return: EMTMResult
     """
-    return libc.EMLoadData(bytes(filename, 'UTF-8'))
+    return EMTMResult(libc.EMLoadData(bytes(filename, 'UTF-8')))
 
 
 def em_clear_data() -> None:
@@ -728,7 +728,7 @@ def tm_load_data(filename: str) -> EMTMResult:
     """
 
     r = libc.TMLoadData(bytes(filename, 'UTF-8'))
-    return r
+    return EMTMResult(r)
 
 
 def tm_clear_data() -> None:

--- a/src/emtmlibpy/emtmlibpy.py
+++ b/src/emtmlibpy/emtmlibpy.py
@@ -3,6 +3,7 @@ Abstraction library for libEMTLib.so from SeaGIS.
 Requires a licence to use, this is just a python wrapping function
 """
 import ctypes
+import dataclasses
 import typing
 from enum import IntEnum, auto
 from collections import namedtuple
@@ -848,3 +849,30 @@ def em_to_dataframe(em_data_type='length') -> pd.DataFrame:
 
     return _dataframe_from_count_and_record_reader(count, record_read_function)
 
+
+@dataclasses.dataclass
+class EmAnnotationDataFrames:
+    """
+    Helper class to represent the Pandas DataFrames which can be read from the an EMObs file and associate them with
+    the relevant loading logic.
+
+    By default, all three possible tables are read automatically, when instantiating this class. To avoid this
+    behaviour for any of the tables, pass an explicit None for that table to the constructor.
+
+    The contained static methods can be used to load only specific tables.
+    """
+    @staticmethod
+    def load_points_from_current_em_file():
+        return _dataframe_from_count_and_record_reader(em_point_count().total, em_get_point)
+
+    @staticmethod
+    def load_3d_points_from_current_em_file():
+        return _dataframe_from_count_and_record_reader(em_3d_point_count(), em_get_3d_point)
+
+    @staticmethod
+    def load_lengths_from_current_em_file():
+        return _dataframe_from_count_and_record_reader(em_get_length_count().total, em_get_length)
+
+    points: pd.DataFrame = dataclasses.field(default_factory=load_points_from_current_em_file.__get__(object))
+    points3d: pd.DataFrame = dataclasses.field(default_factory=load_3d_points_from_current_em_file.__get__(object))
+    lengths: pd.DataFrame = dataclasses.field(default_factory=load_lengths_from_current_em_file.__get__(object))

--- a/src/test_emtmlibpy.py
+++ b/src/test_emtmlibpy.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 SRC_DIR = os.path.abspath(os.path.dirname(__file__))
 TEST_FILES_PATH = os.path.join(SRC_DIR, 'test_files')
 
+assert os.path.exists(TEST_FILES_PATH), f"Please ensure you place the required test files at: {TEST_FILES_PATH}"
 
 class TestEmtmlibpy(unittest.TestCase):
 
@@ -183,3 +184,37 @@ class TestEmtmlibpy(unittest.TestCase):
         length_dataframe = emtm.em_to_dataframe(em_data_type='length')
         point_dataframe = emtm.em_to_dataframe(em_data_type='point')
 
+        points_df = emtm.EmAnnotationDataFrames.load_points_from_current_em_file()
+        points3d_df = emtm.EmAnnotationDataFrames.load_3d_points_from_current_em_file()
+        lengths_df = emtm.EmAnnotationDataFrames.load_lengths_from_current_em_file()
+        self.assertEqual(len(points_df), 35)
+        self.assertEqual(len(points3d_df), 2)
+        self.assertEqual(len(lengths_df), 22)
+
+    def test_starting_with_empty_EmAnnotationDataFrames_object(self):
+        emtm.em_load_data(os.path.join(os.path.join(TEST_FILES_PATH, 'Test.EMObs')))
+        dfs = emtm.EmAnnotationDataFrames(None, None, None)
+        self.assertIs(dfs.points, None)
+        self.assertIs(dfs.points3d, None)
+        self.assertIs(dfs.lengths, None)
+        dfs.points = emtm.EmAnnotationDataFrames.load_points_from_current_em_file()
+        self.assertEqual(len(dfs.points), 35)
+
+    def test_starting_with_partially_empty_EmAnnotationDataFrames_object(self):
+        emtm.em_load_data(os.path.join(os.path.join(TEST_FILES_PATH, 'Test.EMObs')))
+        dfs = emtm.EmAnnotationDataFrames(points=None)
+        self.assertIs(dfs.points, None)
+        self.assertEqual(len(dfs.points3d), 2)
+        self.assertEqual(len(dfs.lengths), 22)
+
+        dfs = emtm.EmAnnotationDataFrames(points=None)
+        self.assertIs(dfs.points, None)
+        self.assertEqual(len(dfs.points3d), 2)
+        self.assertEqual(len(dfs.lengths), 22)
+
+    def test_em_to_dataframes(self):
+        emtm.em_load_data(os.path.join(os.path.join(TEST_FILES_PATH, 'Test.EMObs')))
+        dfs = emtm.EmAnnotationDataFrames()
+        self.assertEqual(len(dfs.points), 35)
+        self.assertEqual(len(dfs.points3d), 2)
+        self.assertEqual(len(dfs.lengths), 22)


### PR DESCRIPTION
As mentioned in #11, this follows on from there (based on that branch, thus the same changes will show up here until we merge that one), but I'm happy to disentangle them completely if preferred.

* Generalised the logic for making a `DataFrame` from a sequence of `ctypes.Structure`s
* Wrapped association of record reading function, length function and name of table into a `dataclass`
* Added tests for the new `dataclass`. They pass for me on Python 3.9 (`dataclass` requires 3.7, but I think the declared requirement of 3.6 was already out of date when I started)
* Updated the required Python version in the packaging metadata (I think -  I'm not versed in the relevant packaging metadata files, so I might have missed something here)